### PR TITLE
Use envconfig split words functionality

### DIFF
--- a/http.go
+++ b/http.go
@@ -20,8 +20,12 @@ import (
 	"github.com/gorilla/handlers"
 )
 
+const (
+	imageMaxWidth = 4096
+)
+
 var (
-	sanitizer *regexp.Regexp = regexp.MustCompile("(^\\/|^/|(^\\./)+|^(\\.\\.)+|^(\\.)+)")
+	sanitizer *regexp.Regexp = regexp.MustCompile(`(^\/|^/|(^\./)+|^(\.\.)+|^(\.)+)`)
 )
 
 func imageQualityForRequest(r *http.Request) int {
@@ -66,8 +70,8 @@ func widthForRequest(r *http.Request) (int64, error) {
 	var err error
 	if r.FormValue("width") != "" {
 		width, err = strconv.ParseInt(r.FormValue("width"), 10, 32)
-		if err != nil || width < 0 || width > ImageMaxWidth {
-			return 0, fmt.Errorf("Invalid width! Limit is %d", ImageMaxWidth)
+		if err != nil || width < 0 || width > imageMaxWidth {
+			return 0, fmt.Errorf("Invalid width! Limit is %d", imageMaxWidth)
 		}
 	}
 
@@ -165,19 +169,19 @@ func handleImage(w http.ResponseWriter, r *http.Request, cache *filecache.FileCa
 func handleHealth(w http.ResponseWriter, r *http.Request, cache *filecache.FileCache, rasterCache *RasterCache) {
 	defer r.Body.Close()
 
-	healthData := struct{
-		Status string
-		FileCacheSize int
+	healthData := struct {
+		Status          string
+		FileCacheSize   int
 		RasterCacheSize int
 	}{
-		Status: "OK",
-		FileCacheSize: cache.Cache.Len(),
+		Status:          "OK",
+		FileCacheSize:   cache.Cache.Len(),
 		RasterCacheSize: rasterCache.rasterizers.Len(),
 	}
 
 	data, err := json.MarshalIndent(healthData, "", "  ")
 	if err != nil {
-		http.Error(w, `{"status": "error", "message":` + err.Error() + `}`, 500)
+		http.Error(w, `{"status": "error", "message":`+err.Error()+`}`, 500)
 		return
 	}
 

--- a/raster_cache.go
+++ b/raster_cache.go
@@ -15,7 +15,7 @@ import (
 import "C"
 
 const (
-	DefaultRasterCacheSize = 20 // open documents
+	defaultRasterCacheSize = 20 // open documents
 )
 
 // RasterCache is a simple LRU cache that holds a number of lazypdf.Rasterizer
@@ -28,7 +28,7 @@ type RasterCache struct {
 
 // NewDefaultRasterCache hands back a cache with the default configuration.
 func NewDefaultRasterCache() (*RasterCache, error) {
-	return NewRasterCache(DefaultRasterCacheSize)
+	return NewRasterCache(defaultRasterCacheSize)
 }
 
 // NewRasterCache creates a new cache of the defined size.
@@ -76,7 +76,7 @@ func (r *RasterCache) Remove(filename string) {
 	}
 }
 
-// Clean out everyting in the rasterizer cache. This will trigger onEvicted() for
+// Purge cleans out everyting in the rasterizer cache. This will trigger onEvicted() for
 // each item in the cache.
 func (r *RasterCache) Purge() {
 	r.rasterizers.Purge()

--- a/raster_cache_test.go
+++ b/raster_cache_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	fixture string = "fixtures/sample.pdf"
+	fixture = "fixtures/sample.pdf"
 )
 
 func Test_NewRasterCache(t *testing.T) {

--- a/redis.go
+++ b/redis.go
@@ -11,17 +11,17 @@ import (
 )
 
 func measureSince(label string, startTime time.Time) {
-	log.Debugf("%s: %s", label, time.Now().Sub(startTime))
+	log.Debugf("%s: %s", label, time.Since(startTime))
 }
 
 // serveRedis runs the Redis protocol server
 func serveRedis(addr string, ringman *ringman.HashRingManager) error {
-	if strings.Index(addr, ":") == -1 {
+	if !strings.Contains(addr, ":") {
 		return errors.New("serveRedis(): Invalid address supplied. Must be of form 'addr:port' or ':port'")
 	}
 
 	if ringman == nil {
-		return errors.New("serveRedis(): HashRingManager was nil!")
+		return errors.New("serveRedis(): HashRingManager was nil")
 	}
 
 	srv := redeo.NewServer(&redeo.Config{Addr: addr})
@@ -76,9 +76,5 @@ func serveRedis(addr string, ringman *ringman.HashRingManager) error {
 	log.Infof("Listening on tcp://%s", srv.Addr())
 	err := srv.ListenAndServe()
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
- make use of https://github.com/kelseyhightower/envconfig/pull/66, yay :)
- also fix some linter issues

TODO:
- [ ] Do we want to do something about errors returned by `r.Body.Close()` and `w.Write()` in http.go?