### PR TITLE
Remove default Memberlist seed

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,12 +97,6 @@ func configureMesosMappings(config *Config) error {
 	return nil
 }
 
-func configureDefaultClusterSeed(config *Config) {
-	defaultClusterSeed := "127.0.0.1:" + strconv.Itoa(MemberlistBindPort)
-
-	config.ClusterSeeds = append(config.ClusterSeeds, defaultClusterSeed)
-}
-
 // Set up some signal handling for kill/term/int and try to exit the
 // cluster and clean out the cache before we exit.
 func handleSignals(fCache *filecache.FileCache, mList *memberlist.Memberlist) {
@@ -172,8 +166,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed set the Mesos config: %s", err)
 	}
-
-	configureDefaultClusterSeed(&config)
 
 	rubberneck.NewPrinter(log.Infof, rubberneck.NoAddLineFeed).Print(config)
 


### PR DESCRIPTION
When starting on a non-seed host and there is no seed online, we should just exit. s6 will keep restarting the service until one of the seeds goes online.

With this change, the healthcheck won't have a chance to succeed before the service is taken down, so deploying from scratch in Singularity will only work when the first instance is scheduled on one of the specified seeds. I'll have to do some refactoring to get this to report healthy a few times before dying, so not sure if we want that... Digging through the Sidecar code, [it looks like](https://github.com/Nitro/sidecar/blob/c56f56097f18619627667e6c16bda6a5fa5e7bc8/main.go#L265) it behaves the same, since the web server is created  [only after](https://github.com/Nitro/sidecar/blob/c56f56097f18619627667e6c16bda6a5fa5e7bc8/main.go#L324) the service joins the Memberlist cluster.