### PR TITLE
Improve shutdown handling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "e6f1cfddc510c312a7623666d0806a4b6bd3a80a"
+  revision = "32923589acded36f59b6760e0e080c830de135c2"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Implements a much better shutdown strategy where we wait either until the cache purge has completed or a timeout has been reached. The timeout is set to 10 seconds currently. Previously Memberlist was being shut down explicitly by the lazyraster service. This is a concern of ringman and not the service. It now calls `ring.Shutdown()` on the `MemberlistRing` instead of directly manipulating memberlist.