### PR TITLE
Remove bucket name from path

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_urlToFilename(t *testing.T) {
+	Convey("urlToFilename()", t, func() {
+		Convey("Strips leading '/documents'", func() {
+			fn := urlToFilename("/documents/testing-bucket/foo-file.pdf")
+
+			So(fn, ShouldNotContainSubstring, "/documents")
+		})
+
+		// TODO This is temporary! Remove when migrated.
+		Convey("Strips the bucket name from the path", func() {
+			fn := urlToFilename("/documents/testing-bucket/foo-file.pdf")
+			So(fn, ShouldNotContainSubstring, "/testing-bucket")
+		})
+
+		Convey("Does not return a leading slash", func() {
+			fn := urlToFilename("/documents/testing-bucket/foo-file.pdf")
+			So(fn, ShouldEqual, "foo-file.pdf")
+		})
+	})
+}


### PR DESCRIPTION
This will strip both `/documents` and the S3 bucket name from file paths. This would ideally be more configurable, but until we've settled this, this PR includes a working fix and some tests.