### PR TITLE
Set memberlist name to advertised name

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,7 +185,9 @@ func main() {
 	mlConfig.BindPort = MemberlistBindPort
 	mlConfig.AdvertiseAddr = config.AdvertiseMemberlistHost
 	mlConfig.AdvertisePort = config.AdvertiseMemberlistPort
-	mlConfig.Name = config.AdvertiseMemberlistHost
+	if config.AdvertiseMemberlistHost != "" {
+		mlConfig.Name = config.AdvertiseMemberlistHost
+	}
 	ring, err := ringman.NewMemberlistRing(
 		mlConfig,
 		config.ClusterSeeds, strconv.Itoa(config.AdvertiseHttpPort), config.ClusterName,

--- a/main.go
+++ b/main.go
@@ -185,6 +185,7 @@ func main() {
 	mlConfig.BindPort = MemberlistBindPort
 	mlConfig.AdvertiseAddr = config.AdvertiseMemberlistHost
 	mlConfig.AdvertisePort = config.AdvertiseMemberlistPort
+	mlConfig.Name = config.AdvertiseMemberlistHost
 	ring, err := ringman.NewMemberlistRing(
 		mlConfig,
 		config.ClusterSeeds, strconv.Itoa(config.AdvertiseHttpPort), config.ClusterName,


### PR DESCRIPTION
This makes the name of the memberlist node the same as the advertised hostname