### PR TITLE
Update deps and add newerThan param

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "2de969621da40cb1c64e2bafada0fe263ed5f824"
+  revision = "f420f7b01acedfa2400597796be8efc13314a3d6"
 
 [[projects]]
   branch = "master"
@@ -23,19 +23,19 @@
   branch = "master"
   name = "github.com/Nitro/urlsign"
   packages = ["."]
-  revision = "f45f7150dda7ac0fb7022989b66b989ca5e96956"
+  revision = "208c5c628b6121a4ee635b4abc5264029483f07f"
 
 [[projects]]
   branch = "master"
   name = "github.com/armon/go-metrics"
   packages = ["."]
-  revision = "023a4bbe4bb9bfb23ee7e1afc8d0abad217641f3"
+  revision = "9a4b6e10bed6220a1665955aa2b75afc91eb10b3"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/s3/s3iface","service/s3/s3manager","service/sts"]
-  revision = "af01be3e6edf79e6f07b5816cfe0d2c6717e5c7f"
-  version = "v1.10.41"
+  revision = "044a61f1536640ce1def6088c0914f5905990202"
+  version = "v1.12.12"
 
 [[projects]]
   branch = "v1"
@@ -44,16 +44,22 @@
   revision = "7a1406ce38ffe267596088da9f1555092cfe4b49"
 
 [[projects]]
+  name = "github.com/djherbis/times"
+  packages = ["."]
+  revision = "95292e44976d1217cf3611dc7c8d9466877d3ed5"
+  version = "v1.0.1"
+
+[[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
-  version = "v1.28.2"
+  revision = "5b3e00af70a9484542169a976dcab8d03e601a17"
+  version = "v1.30.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/gopherjs/gopherjs"
   packages = ["js"]
-  revision = "b40cd48c38f9a18eb3db20d163bad78de12cf0b7"
+  revision = "a0a7cfed7b2a54080888fd2b3d4a3ec14562c86c"
 
 [[projects]]
   name = "github.com/gorilla/handlers"
@@ -100,8 +106,7 @@
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
-  version = "0.2.2"
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/jtolds/gls"
@@ -118,8 +123,8 @@
 [[projects]]
   branch = "master"
   name = "github.com/miekg/dns"
-  packages = ["."]
-  revision = "e4205768578dc90c2669e75a2f8a8bf77e3083a4"
+  packages = [".","internal/socket"]
+  revision = "b02ebddc7f2b55c5bb78aead3121c2e5cfc715d7"
 
 [[projects]]
   branch = "master"
@@ -154,8 +159,8 @@
 [[projects]]
   name = "github.com/smartystreets/assertions"
   packages = [".","internal/go-render/render","internal/oglematchers"]
-  revision = "9c0ea8acbc1d8ad689f9e6fe0c1fa5838e0cabc2"
-  version = "1.7.0"
+  revision = "ff1918e1e5a13a74014644ae7c1e0ba2f791364d"
+  version = "1.8.0"
 
 [[projects]]
   name = "github.com/smartystreets/goconvey"
@@ -184,13 +189,13 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "9ba3862cf6a5452ae579de98f9364dd2e544844c"
+  revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "a5054c7c1385fd50d9394475365355a87a7873ec"
+  revision = "8dbc5d05d6edcc104950cc299a1ce6641235bc86"
 
 [solve-meta]
   analyzer-name = "dep"


### PR DESCRIPTION
Adds a newerThan parameter to the http handler to allow cache busting in a simple way, based on shared clock and modified timestamp.