### PR TITLE
Don't 500 on closed sockets

### DIFF
--- a/http.go
+++ b/http.go
@@ -345,7 +345,7 @@ func (h *RasterHttpServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", rParams.ImageType)
-	w.Header().Set("Cache-Control", "max-age=3600")
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", int64(SigningBucketSize) / 1e9))
 
 	if rParams.ImageType == "image/jpeg" {
 		err = jpeg.Encode(w, image, &jpeg.Options{Quality: rParams.ImageQuality})


### PR DESCRIPTION
This prevents logging 500 errors when the remote socket was closed. Instead we log that we aborted the call and a 200 OK. This prevents the logs from seeing 500 errors when nothing was wrong.