### PR TITLE
Add support for Sidecar-backed Ringman

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,6 +3,18 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/Azure/go-ansiterm"
+  packages = [".","winterm"]
+  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
+
+[[projects]]
+  name = "github.com/Microsoft/go-winio"
+  packages = ["."]
+  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
+  version = "v0.4.5"
+
+[[projects]]
+  branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
   revision = "f420f7b01acedfa2400597796be8efc13314a3d6"
@@ -17,13 +29,25 @@
   branch = "master"
   name = "github.com/Nitro/ringman"
   packages = ["."]
-  revision = "94fc00afbf74f59480bf1d93384e083702538626"
+  revision = "42f7d31407d21c7fa5e590758dbeea56fb3e0d24"
+
+[[projects]]
+  name = "github.com/Nitro/sidecar"
+  packages = ["catalog","output","receiver","service"]
+  revision = "2bded9464d4dabb48de9d52605c573e1791b4c2c"
+  version = "v2.0.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/Nitro/urlsign"
   packages = ["."]
   revision = "208c5c628b6121a4ee635b4abc5264029483f07f"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/Nvveen/Gotty"
+  packages = ["."]
+  revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
 
 [[projects]]
   branch = "master"
@@ -44,16 +68,51 @@
   revision = "7a1406ce38ffe267596088da9f1555092cfe4b49"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/containerd/continuity"
+  packages = ["pathdriver"]
+  revision = "0cf103d319cc2d7efe085224094f466d1f8b9640"
+
+[[projects]]
   name = "github.com/djherbis/times"
   packages = ["."]
   revision = "95292e44976d1217cf3611dc7c8d9466877d3ed5"
   version = "v1.0.1"
 
 [[projects]]
+  name = "github.com/docker/docker"
+  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  revision = "fe8aac6f5ae413a967adb0adad0b54abdfb825c4"
+
+[[projects]]
+  name = "github.com/docker/go-connections"
+  packages = ["nat"]
+  revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "github.com/docker/go-units"
+  packages = ["."]
+  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
+  version = "v0.3.2"
+
+[[projects]]
+  name = "github.com/fsouza/go-dockerclient"
+  packages = ["."]
+  revision = "2ff310040c161b75fa19fb9b287a90a6e03c0012"
+  version = "1.1"
+
+[[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "5b3e00af70a9484542169a976dcab8d03e601a17"
   version = "v1.30.0"
+
+[[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = ["proto"]
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
 
 [[projects]]
   branch = "master"
@@ -128,6 +187,42 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/mohae/deepcopy"
+  packages = ["."]
+  revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
+
+[[projects]]
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
+
+[[projects]]
+  name = "github.com/opencontainers/image-spec"
+  packages = ["specs-go","specs-go/v1"]
+  revision = "d60099175f88c47cd379c4738d158884749ed235"
+  version = "v1.0.1"
+
+[[projects]]
+  name = "github.com/opencontainers/runc"
+  packages = ["libcontainer/system","libcontainer/user"]
+  revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
+  version = "v0.1.1"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/pquerna/ffjson"
+  packages = ["fflib/v1","fflib/v1/internal"]
+  revision = "d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac"
+
+[[projects]]
+  branch = "master"
   name = "github.com/relistan/go-director"
   packages = ["."]
   revision = "9273dae8c839a114aa4472165f84e057d5b12e09"
@@ -190,6 +285,12 @@
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/net"
+  packages = ["context","context/ctxhttp"]
+  revision = "dc871a5d77e227f5bbf6545176ef3eeebf87e76e"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,6 +26,10 @@ ignored = ["github.com/Nitro/lazypdf"]
 
 [[constraint]]
   branch = "master"
+  name = "github.com/Nitro/sidecar"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/Nitro/memberlist"
 
 [[constraint]]


### PR DESCRIPTION
This adds a `SidecarRing` from the `ringman` package, allowing Lazyraster to be backed by the Sidecar service discovery platform instead of running its own version of Memberlist.