### PR TITLE
Upgrade filecache and add it as a dep dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "df38fb34c79f0d5a7c656531ac3446d81af434cb"
+  revision = "bdaae1f3324d8609c00d996db78c5db416e0c16a"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "f420f7b01acedfa2400597796be8efc13314a3d6"
+  revision = "df38fb34c79f0d5a7c656531ac3446d81af434cb"
 
 [[projects]]
   branch = "master"
@@ -301,6 +301,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ee5c1a8244cdbcfff8e86ab6aa03950c7ccfd29612bd14c23eb6345d5a120ea"
+  inputs-digest = "9ddda61123ba861a19b40237c192e2f004ced01bffec4789c2e2924ece835669"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,10 @@ ignored = ["github.com/Nitro/lazypdf"]
   name = "github.com/Nitro/ringman"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/Nitro/filecache"
+
+[[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "0.10.0-16-gcd7d1bb"
 

--- a/http.go
+++ b/http.go
@@ -25,9 +25,11 @@ import (
 
 const (
 	// ImageMaxWidth is the maximum supported image width
-	ImageMaxWidth     = 4096
-	ImageMaxScale     = 3.0
-	SigningBucketSize = 8 * time.Hour
+	ImageMaxWidth      = 4096
+	ImageMaxScale      = 3.0
+	SigningBucketSize  = 8 * time.Hour
+	ServerReadTimeout  = 10 * time.Second
+	ServerWriteTimeout = 15 * time.Second
 )
 
 var (
@@ -316,7 +318,7 @@ func (h *RasterHttpServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	raster, err := h.rasterCache.GetRasterizer(rParams.StoragePath)
 	if err != nil {
 		log.Errorf("Unable to get rasterizer for %s: '%s'", rParams.StoragePath, err)
-		http.Error( w, fmt.Sprintf("Error encountered while processing pdf %s: '%s'", rParams.StoragePath, err), 500)
+		http.Error(w, fmt.Sprintf("Error encountered while processing pdf %s: '%s'", rParams.StoragePath, err), 500)
 		return
 	}
 
@@ -345,7 +347,7 @@ func (h *RasterHttpServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", rParams.ImageType)
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", int64(SigningBucketSize) / 1e9))
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", int64(SigningBucketSize)/1e9))
 
 	if rParams.ImageType == "image/jpeg" {
 		err = jpeg.Encode(w, image, &jpeg.Options{Quality: rParams.ImageQuality})
@@ -426,8 +428,8 @@ func configureServer(config *Config, mux http.Handler) *http.Server {
 	return &http.Server{
 		Addr:           fmt.Sprintf(":%d", config.HttpPort),
 		Handler:        mux,
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   15 * time.Second,
+		ReadTimeout:    ServerReadTimeout,
+		WriteTimeout:   ServerWriteTimeout,
 		MaxHeaderBytes: 1 << 20, // 1 KB
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -86,7 +86,7 @@ func Test_EndToEnd(t *testing.T) {
 		didDownload = false
 		downloadCount = 0
 
-		cache, _ := filecache.NewS3Cache(10, os.TempDir(), "aragorn-foo", "gondor-north-1")
+		cache, _ := filecache.NewS3Cache(10, os.TempDir(), "aragorn-foo", "gondor-north-1", 1*time.Millisecond)
 		cache.DownloadFunc = mockDownloader
 
 		rasterCache, _ := NewRasterCache(1)

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func main() {
 
 	// Set up an S3-backed filecache to underly the rasterCache
 	fCache, err := filecache.NewS3Cache(
-		config.CacheSize, config.BaseDir, config.S3Bucket, config.AwsRegion,
+		config.CacheSize, config.BaseDir, config.S3Bucket, config.AwsRegion, ServerWriteTimeout,
 	)
 	if err != nil {
 		log.Fatalf("Unable to create LRU cache: %s", err)


### PR DESCRIPTION
This fixes a potential resource leak when fetching files from S3. Details here:  https://github.com/Nitro/filecache/pull/5

It also passes the download timeout to filecache.

TODO:
- [x] Merge https://github.com/Nitro/filecache/pull/6 and update dependencies.