### PR TITLE
Multi bucket support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "bdaae1f3324d8609c00d996db78c5db416e0c16a"
+  revision = "76bcf12ca0f8ba4495cc0bbe7bae35382daf45f9"
 
 [[projects]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,21 @@ with:
  * `SERVICE_NAME`: the name of the application in New Relic (e.g. 'foo-service')
  * `ENVIRONMENT_NAME`: appended to `SERVICE_NAME` (e.g. 'foo-service-prod')
 
+Local Development
+-----------------
+
+If you are running this locally for development purposes, you will probably
+want to use the following options to get started:
+
+```bash
+$ RASTER_RING_TYPE=memberlist RASTER_LOGGING_LEVEL=debug ./lazyraster
+```
+
+This will use the Memberlist clustering library and not require an external
+Sidecar service discovery system. It will also enable debug logging level which
+can help in understanding where things went wrong.
+
 Copyright
 ---------
 
-Copyright (c) 2017 Nitro Software.
+Copyright (c) 2017-2018 Nitro Software.

--- a/build
+++ b/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Newer OSX needs an include path for OpenSSL
+if [[ `uname -s` == "Darwin" ]]; then
+        export CGO_LDFLAGS="-L/usr/local/opt/openssl/lib"
+fi
+
+go build

--- a/http.go
+++ b/http.go
@@ -177,7 +177,7 @@ func (h *RasterHttpServer) isValidSignature(url string, w http.ResponseWriter) b
 	return true
 }
 
-// Allows us to manually clear out the raster cache
+// handleClearRasterCache allows us to manually clear out the raster cache
 func (h *RasterHttpServer) handleClearRasterCache(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
@@ -195,17 +195,12 @@ func (h *RasterHttpServer) handleClearRasterCache(w http.ResponseWriter, r *http
 // urlToFilename converts the incoming URL path into a cached filename (this is
 // the filename on the backing store, not the cached filename locally).
 func urlToFilename(url string) string {
-	pathParts := strings.Split(strings.TrimLeft(url, "/documents"), "/")
+	pathParts := strings.Split(strings.TrimPrefix(url, "/documents/"), "/")
 	if len(pathParts) < 1 {
 		return ""
 	}
 
-	base := 0
-
-	// XXX Temporary! Strip bucket name from URLs
-	base++
-
-	return strings.Join(pathParts[base:], "/")
+	return strings.Join(pathParts, "/")
 }
 
 func (h *RasterHttpServer) processParams(r *http.Request) (*RasterParams, int, error) {
@@ -313,7 +308,7 @@ func (h *RasterHttpServer) handleImage(w http.ResponseWriter, r *http.Request) {
 	t2 := h.beginTrace("rasterize")
 	defer h.endTrace(t2)
 
-	// Get ahold of a rasterizer for this document, either from the cache,
+	// Get ahold of a rasterizer for this document either from the cache
 	// or newly constructed by the cache.
 	raster, err := h.rasterCache.GetRasterizer(rParams.StoragePath)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -196,7 +196,8 @@ func (h *RasterHttpServer) handleClearRasterCache(w http.ResponseWriter, r *http
 // the filename on the backing store, not the cached filename locally).
 func urlToFilename(url string) string {
 	pathParts := strings.Split(strings.TrimPrefix(url, "/documents/"), "/")
-	if len(pathParts) < 1 {
+	// We need at least a bucket and filename
+	if len(pathParts) < 2 {
 		return ""
 	}
 

--- a/http_test.go
+++ b/http_test.go
@@ -76,7 +76,7 @@ func Test_urlToFilename(t *testing.T) {
 
 		Convey("Does not return a leading slash", func() {
 			fn := urlToFilename("/documents/testing-bucket/foo-file.pdf")
-			So(fn, ShouldEqual, "foo-file.pdf")
+			So(fn, ShouldEqual, "testing-bucket/foo-file.pdf")
 		})
 	})
 }
@@ -102,7 +102,7 @@ func Test_EndToEnd(t *testing.T) {
 		filename := "73/069741a92a2f641eb428ba6d12ccb9af" // cache file for sample.pdf
 
 		Reset(func() {
-			os.Remove(cache.GetFileName("sample.pdf"))
+			os.Remove(cache.GetFileName("somewhere/sample.pdf"))
 		})
 
 		Convey("Handling error conditions", func() {
@@ -116,7 +116,7 @@ func Test_EndToEnd(t *testing.T) {
 
 			Convey("When the page is not contained in the document", func() {
 				os.MkdirAll(filepath.Join(os.TempDir(), filepath.Dir(filename)), 0755)
-				CopyFile(cache.GetFileName("sample.pdf"), "fixtures/sample.pdf", 0644)
+				CopyFile(cache.GetFileName("somewhere/sample.pdf"), "fixtures/sample.pdf", 0644)
 
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=10", nil)
 				recorder := httptest.NewRecorder()
@@ -127,7 +127,7 @@ func Test_EndToEnd(t *testing.T) {
 
 			Convey("When the page is not valid", func() {
 				os.MkdirAll(filepath.Join(os.TempDir(), filepath.Dir(filename)), 0755)
-				CopyFile(cache.GetFileName("sample.pdf"), "fixtures/sample.pdf", 0644)
+				CopyFile(cache.GetFileName("somewhere/sample.pdf"), "fixtures/sample.pdf", 0644)
 
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=-1", nil)
 				recorder := httptest.NewRecorder()
@@ -204,7 +204,7 @@ func Test_EndToEnd(t *testing.T) {
 
 		Convey("When everything is working", func() {
 			os.MkdirAll(filepath.Join(os.TempDir(), filepath.Dir(filename)), 0755)
-			CopyFile(cache.GetFileName("sample.pdf"), "fixtures/sample.pdf", 0644)
+			CopyFile(cache.GetFileName("somewhere/sample.pdf"), "fixtures/sample.pdf", 0644)
 			recorder := httptest.NewRecorder()
 
 			Convey("Handles a normal request", func() {
@@ -257,12 +257,12 @@ func Test_EndToEnd(t *testing.T) {
 		})
 
 		Convey("When timestamps are supplied for cache busting", func() {
-			filename := cache.GetFileName("sample.pdf")
+			filename := cache.GetFileName("somewhere/sample.pdf")
 			os.MkdirAll(filepath.Dir(filename), 0755)
 			CopyFile(filename, "fixtures/sample.pdf", 0644)
 			recorder := httptest.NewRecorder()
 
-			cache.Cache.Add("sample.pdf", filename)
+			cache.Cache.Add("somewhere/sample.pdf", filename)
 			// On reload the file gets evicted/deleted so we need to put it back
 			reloadableDownloader := func(fname string, localPath string) error {
 				CopyFile(filename, "fixtures/sample.pdf", 0644)

--- a/raster_cache.go
+++ b/raster_cache.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/golang-lru"
 )
 
-// #cgo CFLAGS: -I../lazypdf -I../lazypdf/mupdf-1.11-source/include -I../lazypdf/mupdf-1.11-source/include/mupdf -I../lazypdf/mupdf-1.11-source/thirdparty/openjpeg -I../lazypdf/mupdf-1.11-source/thirdparty/jbig2dec -I../lazypdf/mupdf-1.11-source/thirdparty/zlib -I../lazypdf/mupdf-1.11-source/thirdparty/jpeg -I../lazypdf/mupdf-1.11-source/thirdparty/freetype
-// #cgo LDFLAGS: -L../lazypdf/mupdf-1.11-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
+// #cgo CFLAGS: -I../lazypdf -I../lazypdf/mupdf-1.12.0-source/include -I../lazypdf/mupdf-1.12.0-source/include/mupdf -I../lazypdf/mupdf-1.12.0-source/thirdparty/openjpeg -I../lazypdf/mupdf-1.12.0-source/thirdparty/jbig2dec -I../lazypdf/mupdf-1.12.0-source/thirdparty/zlib -I../lazypdf/mupdf-1.12.0-source/thirdparty/jpeg -I../lazypdf/mupdf-1.12.0-source/thirdparty/freetype
+// #cgo LDFLAGS: -L../lazypdf/mupdf-1.12.0-source/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 


### PR DESCRIPTION
This completes the work that was done on handling multiple S3 buckets. Rather than ignoring the first part of the path, this now passes the bucket name into the `Filecache` request. With Nitro/filecache#7 merged, this will then handle multi-region, multi-bucket caching.