### PR TITLE
Complete removal of S3 bucket requirement

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "76bcf12ca0f8ba4495cc0bbe7bae35382daf45f9"
+  revision = "21e2cc28a59a97bbcf9115726186fc6c13283d5b"
 
 [[projects]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ variables. These include the following:
  * `RASTER_BASE_DIR`: The location where cached files are to be stored and served.
  * `RASTER_HTTP_PORT`: The port to listen on for HTTP connections.
  * `RASTER_ADVERTISE_HTTP_PORT`: The advertised host port which gets mapped to RASTER_HTTP_PORT.
- * `RASTER_AWS_REGION`: The AWS Region to use when serving from an S3 bucket.
- * `RASTER_S3_BUCKET`: The backing S3 bucket to use for fetching files.
+ * `RASTER_AWS_REGION`: The AWS Region fallback to use when S3 region lookup fails.
  * `RASTER_CLUSTER_SEEDS`: The seeds to use to start the gossip ring.
  * `RASTER_CACHE_SIZE`: The number of file objects to cache at any one time. (disk)
  * `RASTER_RASTER_CACHE_SIZE`: The number of Rasterizer objects to cache at any one time. (memory)

--- a/http_test.go
+++ b/http_test.go
@@ -86,7 +86,7 @@ func Test_EndToEnd(t *testing.T) {
 		didDownload = false
 		downloadCount = 0
 
-		cache, _ := filecache.NewS3Cache(10, os.TempDir(), "aragorn-foo", "gondor-north-1", 1*time.Millisecond)
+		cache, _ := filecache.NewS3Cache(10, os.TempDir(), "gondor-north-1", 1*time.Millisecond)
 		cache.DownloadFunc = mockDownloader
 
 		rasterCache, _ := NewRasterCache(1)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ type Config struct {
 	HttpPort                int      `envconfig:"HTTP_PORT" default:"8000"`
 	AdvertiseHttpPort       int      `envconfig:"ADVERTISE_HTTP_PORT" default:"8000"`
 	AwsRegion               string   `envconfig:"AWS_REGION" default:"us-west-1"`
-	S3Bucket                string   `envconfig:"S3_BUCKET" default:"nitro-junk"`
 	ClusterSeeds            []string `envconfig:"CLUSTER_SEEDS"`
 	CacheSize               int      `envconfig:"CACHE_SIZE" default:"512"`
 	RedisPort               int      `envconfig:"REDIS_PORT" default:"6379"`
@@ -225,7 +224,7 @@ func main() {
 
 	// Set up an S3-backed filecache to underly the rasterCache
 	fCache, err := filecache.NewS3Cache(
-		config.CacheSize, config.BaseDir, config.S3Bucket, config.AwsRegion, ServerWriteTimeout,
+		config.CacheSize, config.BaseDir, config.AwsRegion, ServerWriteTimeout,
 	)
 	if err != nil {
 		log.Fatalf("Unable to create LRU cache: %s", err)


### PR DESCRIPTION
Seems that I did not do a complete job in filecache#7. This change is the partner to that one, removing the requirement to pass a statically configured S3 bucket.