### PR TITLE
Re-enable pprof

### DIFF
--- a/http.go
+++ b/http.go
@@ -468,7 +468,7 @@ func serveHttp(config *Config, cache *filecache.FileCache, ring ringman.Ring,
 	// ------------------------------------------------------------------------
 	// Route definitions
 	// ------------------------------------------------------------------------
-	mux := http.NewServeMux()
+	mux := http.DefaultServeMux
 	mux.HandleFunc("/favicon.ico", http.NotFound) // Browsers look for this
 	mux.Handle("/hashring/", http.StripPrefix("/hashring", ring.HttpMux()))
 	mux.HandleFunc("/health", handle(h.handleHealth))

--- a/raster_cache_test.go
+++ b/raster_cache_test.go
@@ -73,7 +73,7 @@ func Test_Remove(t *testing.T) {
 
 			raster2, _ := cache.GetRasterizer(fixture)
 			So(raster2, ShouldNotBeNil)
-			So(raster, ShouldNotEqual, raster2)
+			So(raster, ShouldNotPointTo, raster2)
 		})
 	})
 }


### PR DESCRIPTION
pprof attaches its handlers on `DefaultServeMux`. If we can't use that one, then we can re-add the pprof routes manually or switch to Gorilla mux.