### PR TITLE
Files with no extension

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,7 +20,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "21e2cc28a59a97bbcf9115726186fc6c13283d5b"
+  revision = "e738b9c84d72864474e3e96d23e4a3cee1ab70d1"
 
 [[projects]]
   branch = "master"

--- a/main.go
+++ b/main.go
@@ -230,6 +230,9 @@ func main() {
 		log.Fatalf("Unable to create LRU cache: %s", err)
 	}
 
+	// If we get a document from S3 with no extension, assume PDF
+	fCache.DefaultExtension = ".pdf"
+
 	// Wrap the S3 download function with Gorelic to report on S3 times
 	if agent != nil {
 		origFunc := fCache.DownloadFunc


### PR DESCRIPTION
With @mihaitodor . We will append `.pdf` to any file in the local cache that doesn't contain a file extension already. This should prevent most errors from MuPDF not understanding the document handler to use.