### PR TITLE
Get rid of the external libraries already bundled into mupdfthird.a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 before_install:
-  - sudo apt-get install -y zlib1g libpng12-0 ca-certificates
+  - sudo apt-get install -y ca-certificates
   - go get -d github.com/Nitro/lazypdf && (cd ${GOPATH}/src/github.com/Nitro/lazypdf && ./build)
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 before_install:
-  - sudo apt-get install -y libjpeg62 zlib1g libjbig2dec0 libjbig2dec0-dev libfreetype6 libpng12-0 ca-certificates
+  - sudo apt-get install -y zlib1g libpng12-0 ca-certificates
   - go get -d github.com/Nitro/lazypdf && (cd ${GOPATH}/src/github.com/Nitro/lazypdf && ./build)
 
 install:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:14.04
 
 RUN apt-get update && apt-get install -y \
                                 curl \
-                                zlib1g \
-                                libpng12-0 \
                                 ca-certificates
 
 # Install S6 from static bins

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,7 @@ FROM ubuntu:14.04
 
 RUN apt-get update && apt-get install -y \
                                 curl \
-                                libjpeg62 \
                                 zlib1g \
-                                libjbig2dec0 \
-                                libfreetype6 \
                                 libpng12-0 \
                                 ca-certificates
 

--- a/raster_cache.go
+++ b/raster_cache.go
@@ -10,7 +10,7 @@ import (
 )
 
 // #cgo CFLAGS: -I../lazypdf -I../lazypdf/mupdf/include -I../lazypdf/mupdf/include/mupdf -I../lazypdf/mupdf/thirdparty/openjpeg -I../lazypdf/mupdf/thirdparty/jbig2dec -I../lazypdf/mupdf/thirdparty/zlib -I../lazypdf/mupdf/thirdparty/jpeg -I../lazypdf/mupdf/thirdparty/freetype
-// #cgo LDFLAGS: -L../lazypdf/mupdf/build/release -lmupdf -lmupdfthird -lm -ljbig2dec -lz -lfreetype -ljpeg -lcrypto -lpthread
+// #cgo LDFLAGS: -L../lazypdf/mupdf/build/release -lmupdf -lmupdfthird -lm -lz -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 

--- a/raster_cache.go
+++ b/raster_cache.go
@@ -10,7 +10,7 @@ import (
 )
 
 // #cgo CFLAGS: -I../lazypdf -I../lazypdf/mupdf/include -I../lazypdf/mupdf/include/mupdf -I../lazypdf/mupdf/thirdparty/openjpeg -I../lazypdf/mupdf/thirdparty/jbig2dec -I../lazypdf/mupdf/thirdparty/zlib -I../lazypdf/mupdf/thirdparty/jpeg -I../lazypdf/mupdf/thirdparty/freetype
-// #cgo LDFLAGS: -L../lazypdf/mupdf/build/release -lmupdf -lmupdfthird -lm -lz -lcrypto -lpthread
+// #cgo LDFLAGS: -L../lazypdf/mupdf/build/release -lmupdf -lmupdfthird -lm -lcrypto -lpthread
 // #include <faster_raster.h>
 import "C"
 


### PR DESCRIPTION
Similar to issue in [lazypdf](https://github.com/Nitro/lazypdf/pull/21) about using non needed external libraries, this commit will do the following changes:

- Update cgo linker flags to link only from lib mupdfthird 
- Remove the libraries from the [Dockerfile](docker/Dockerfile)
- Remove the libraries from the [travis config](.travis.yml)