### PR TITLE
Return the document metadata when requesting document URI w/o page parameter

### DIFF
--- a/http.go
+++ b/http.go
@@ -54,6 +54,12 @@ type RasterImageParams struct {
 	ImageQuality int
 }
 
+// DocumentMetadata contains information about the requested document
+type DocumentMetadata struct {
+	Filename  string
+	PageCount int
+}
+
 // imageQualityForRequest parses out the value for the imageQuality parameter
 func imageQualityForRequest(r *http.Request) int {
 	imageQuality := 100
@@ -356,10 +362,7 @@ func (h *RasterHttpServer) handleDocument(w http.ResponseWriter, r *http.Request
 }
 
 func (h *RasterHttpServer) handleDocumentInfo(w http.ResponseWriter, docParams *RasterDocumentParams, raster *lazypdf.Rasterizer) {
-	payload := struct {
-		Filename  string
-		PageCount int
-	}{
+	payload := DocumentMetadata{
 		Filename:  docParams.Filename,
 		PageCount: raster.GetPageCount(),
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -82,7 +82,7 @@ func Test_urlToFilename(t *testing.T) {
 }
 
 func Test_EndToEnd(t *testing.T) {
-	Convey("End-to-end testing handleImage()", t, func() {
+	Convey("End-to-end testing handleDocument()", t, func() {
 		didDownload = false
 		downloadCount = 0
 
@@ -113,7 +113,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/asdf.pdf", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 				So(recorder.Result().StatusCode, ShouldEqual, 400)
 			})
 
@@ -124,7 +124,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=10", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 				So(recorder.Result().StatusCode, ShouldEqual, 404)
 			})
 
@@ -135,7 +135,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=-1", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -147,7 +147,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/asdf.pdf", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -160,7 +160,7 @@ func Test_EndToEnd(t *testing.T) {
 				recorder := httptest.NewRecorder()
 				h.urlSecret = "secret"
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -172,7 +172,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&width=-300", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -184,7 +184,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&width=300000", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -196,7 +196,7 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/sample.pdf?page=1", nil)
 				recorder := httptest.NewRecorder()
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -215,7 +215,7 @@ func Test_EndToEnd(t *testing.T) {
 			Convey("Handles a normal request", func() {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1", nil)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -228,7 +228,7 @@ func Test_EndToEnd(t *testing.T) {
 			Convey("Handles a jpeg", func() {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&width=1024&quality=75&imageType=image/jpeg", nil)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -240,7 +240,7 @@ func Test_EndToEnd(t *testing.T) {
 			Convey("Handles a png", func() {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&width=1024&quality=75&imageType=image/png", nil)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -252,7 +252,7 @@ func Test_EndToEnd(t *testing.T) {
 			Convey("Handles a bunch of options", func() {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&scale=1.5&quality=75", nil)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -263,7 +263,7 @@ func Test_EndToEnd(t *testing.T) {
 			Convey("Handles a file with no file extension", func() {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample?page=1&scale=1.5&quality=75", nil)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
@@ -294,7 +294,7 @@ func Test_EndToEnd(t *testing.T) {
 					nil,
 				)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				So(didDownload, ShouldBeTrue)
 			})
@@ -302,7 +302,7 @@ func Test_EndToEnd(t *testing.T) {
 			Convey("Doesn't download if the timestamp is absent", func() {
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1", nil)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				So(didDownload, ShouldBeFalse)
 			})
@@ -315,7 +315,7 @@ func Test_EndToEnd(t *testing.T) {
 					nil,
 				)
 
-				h.handleImage(recorder, req)
+				h.handleDocument(recorder, req)
 
 				So(didDownload, ShouldBeFalse)
 

--- a/http_test.go
+++ b/http_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,28 +15,6 @@ import (
 
 	"github.com/Nitro/filecache"
 	. "github.com/smartystreets/goconvey/convey"
-)
-
-var (
-	didDownload         bool
-	downloadShouldSleep bool
-	downloadShouldError bool
-	downloadCount       int
-	countLock           sync.Mutex
-
-	mockDownloader = func(fname string, localPath string) error {
-		if downloadShouldError {
-			return errors.New("Oh no! Tragedy!")
-		}
-		if downloadShouldSleep {
-			time.Sleep(10 * time.Millisecond)
-		}
-		countLock.Lock()
-		downloadCount += 1
-		countLock.Unlock()
-		didDownload = true
-		return nil
-	}
 )
 
 // CopyFile copies the contents from src to dst using io.Copy.
@@ -83,8 +62,25 @@ func Test_urlToFilename(t *testing.T) {
 
 func Test_EndToEnd(t *testing.T) {
 	Convey("End-to-end testing handleDocument()", t, func() {
-		didDownload = false
-		downloadCount = 0
+		didDownload := false
+		downloadCount := 0
+		downloadShouldSleep := false
+		downloadShouldError := false
+		var countLock sync.Mutex
+
+		mockDownloader := func(fname string, localPath string) error {
+			if downloadShouldError {
+				return errors.New("Oh no! Tragedy!")
+			}
+			if downloadShouldSleep {
+				time.Sleep(10 * time.Millisecond)
+			}
+			countLock.Lock()
+			downloadCount += 1
+			countLock.Unlock()
+			didDownload = true
+			return nil
+		}
 
 		cache, _ := filecache.NewS3Cache(10, os.TempDir(), "gondor-north-1", 1*time.Millisecond)
 		cache.DownloadFunc = mockDownloader
@@ -109,12 +105,17 @@ func Test_EndToEnd(t *testing.T) {
 		})
 
 		Convey("Handling error conditions", func() {
-			Convey("When no page is specified", func() {
+			Convey("When the document is not written properly to disk", func() {
+				// Fetch a file which doesn't exist, but leave downloadShouldError = false
+				// so mockDownloader doesn't return an error.
 				req := httptest.NewRequest("GET", "/documents/somewhere/asdf.pdf", nil)
 				recorder := httptest.NewRecorder()
 
 				h.handleDocument(recorder, req)
-				So(recorder.Result().StatusCode, ShouldEqual, 400)
+				body, err := ioutil.ReadAll(recorder.Result().Body)
+				So(err, ShouldBeNil)
+				So(recorder.Result().StatusCode, ShouldEqual, 500)
+				So(string(body), ShouldContainSubstring, "Error encountered while processing pdf")
 			})
 
 			Convey("When the page is not contained in the document", func() {
@@ -147,12 +148,13 @@ func Test_EndToEnd(t *testing.T) {
 				req := httptest.NewRequest("GET", "/documents/somewhere/asdf.pdf", nil)
 				recorder := httptest.NewRecorder()
 
+				downloadShouldError = true
 				h.handleDocument(recorder, req)
 
 				body, err := ioutil.ReadAll(recorder.Result().Body)
 				So(err, ShouldBeNil)
-				So(recorder.Result().StatusCode, ShouldEqual, 400)
-				So(string(body), ShouldContainSubstring, "Invalid page")
+				So(recorder.Result().StatusCode, ShouldEqual, 404)
+				So(string(body), ShouldContainSubstring, "page not found")
 			})
 
 			Convey("Rejects badly/unsigned URLs when signing is required", func() {
@@ -169,6 +171,9 @@ func Test_EndToEnd(t *testing.T) {
 			})
 
 			Convey("Doesn't accept negative width", func() {
+				os.MkdirAll(filepath.Join(os.TempDir(), filepath.Dir(filename)), 0755)
+				CopyFile(cache.GetFileName("somewhere/sample.pdf"), "fixtures/sample.pdf", 0644)
+
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&width=-300", nil)
 				recorder := httptest.NewRecorder()
 
@@ -181,6 +186,9 @@ func Test_EndToEnd(t *testing.T) {
 			})
 
 			Convey("Doesn't accept crazy wide width", func() {
+				os.MkdirAll(filepath.Join(os.TempDir(), filepath.Dir(filename)), 0755)
+				CopyFile(cache.GetFileName("somewhere/sample.pdf"), "fixtures/sample.pdf", 0644)
+
 				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf?page=1&width=300000", nil)
 				recorder := httptest.NewRecorder()
 
@@ -269,6 +277,22 @@ func Test_EndToEnd(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(len(body), ShouldBeGreaterThan, 1024) // We really did get an image
 				So(recorder.Result().StatusCode, ShouldEqual, 200)
+			})
+
+			Convey("Returns document metadata when no page number is specified", func() {
+				req := httptest.NewRequest("GET", "/documents/somewhere/sample.pdf", nil)
+
+				h.handleDocument(recorder, req)
+
+				body, err := ioutil.ReadAll(recorder.Result().Body)
+				So(err, ShouldBeNil)
+				So(recorder.Result().StatusCode, ShouldEqual, 200)
+
+				var meta DocumentMetadata
+				err = json.Unmarshal(body, &meta)
+				So(err, ShouldBeNil)
+				So(meta.Filename, ShouldEqual, "somewhere/sample.pdf")
+				So(meta.PageCount, ShouldEqual, 2)
 			})
 		})
 


### PR DESCRIPTION
This change split the HTTP request processing into 2 parts in order to return the document metadata and update tests:

* Change HTTP request parsing

1. * `processDocumentParams()`, `handleDocument()`: parse the URI and return the JSON body if no page parameter into the request
2. * `processImageParams()`, `handleImage()`: parse the URI and params and return the rasterized image

* Update the tests accordingly recent changes.