### PR TITLE
Use shallow clone when building lazypdf in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_install:
   - sudo apt-get install -y ca-certificates
-  - go get -d github.com/Nitro/lazypdf && (cd ${GOPATH}/src/github.com/Nitro/lazypdf && ./build)
+  - go get -d github.com/Nitro/lazypdf && (cd ${GOPATH}/src/github.com/Nitro/lazypdf && SHALLOW_CLONE=true ./build)
 
 install:
   - go get github.com/golang/dep/cmd/dep && dep ensure


### PR DESCRIPTION
Follow-up on the [lazypdf PR](https://github.com/Nitro/lazypdf/pull/23).