### PR TITLE
Update filecache and remove redundant code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,7 +20,7 @@
   branch = "master"
   name = "github.com/Nitro/filecache"
   packages = ["."]
-  revision = "426b69f7275516c7e40d204b67855971448b46d0"
+  revision = "7042715f1fd21cb9f91ac4556374826249d45eca"
 
 [[projects]]
   branch = "master"

--- a/http.go
+++ b/http.go
@@ -209,7 +209,7 @@ func getHTTPHeaders(r *http.Request) map[string]string {
 
 	headers := make(map[string]string, len(r.Header))
 	for header := range r.Header {
-		headers[strings.ToLower(header)] = r.Header.Get(header)
+		headers[header] = r.Header.Get(header)
 	}
 
 	return headers


### PR DESCRIPTION
The `strings.ToLower` stuff is now done in `DownloadRecord.GetHashedArguments()` inside `filecache`.