### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 Nitro Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ A caching PDF rasterizer that uses a filecache and a hashring to distribute load
 
 MuPDF is the PDF engine that drives the rasterizer.
 
+License Restriction
+-------------------
+
+This project is released under an [MIT license](LICENSE), but it relies on the AGPL code from [lazypdf](https://github.com/Nitro/lazypdf). Therefore, running it must comply with the terms and conditions from [this license](https://github.com/Nitro/lazypdf/blob/master/LICENSE). Sorry about that!
+
 Building It
 -----------
 


### PR DESCRIPTION
Looks like we forgot to add the license to this project. I just copied [the one](https://github.com/Nitro/lazypdf/blob/master/LICENSE) we have in lazypdf. WDYT?