### PR TITLE
Enable URL signing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ variables. These include the following:
  * `RASTER_CLUSTER_NAME`: The name of the Memberlist cluster.
  * `RASTER_ADVERTISE_MEMBERLIST_HOST`: The IP / hostname advertised by Memberlist.
  * `RASTER_ADVERTISE_MEMBERLIST_PORT`: The port advertised by Memberlist.
- * `RASTER_URL_SIGNING_SECRET`: A secret to use when validating signed URLs (optional).
+ * `RASTER_URL_SIGNING_SECRET`: A secret to use when validating signed URLs (default: `deadbeef`). Set it to empty string to disable signature validation.
  * `RASTER_LOGGING_LEVEL`: The cut off level for log messages. (`debug`, `info`, `warn`, `error`)
  * `RASTER_RING_TYPE`: Use `sidecar` or `memberlist` backing for hash ring? (default: `sidecar`)
  * `RASTER_SIDECAR_SERVICE_NAME`: The name to lookup in Sidecar when using Sidecar backing.

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ type Config struct {
 	SidecarUrl              string   `envconfig:"SIDECAR_URL" default:"http://192.168.168.168:7777/api/state.json"`
 	SidecarServiceName      string   `envconfig:"SIDECAR_SERVICE_NAME" default:"lazyraster"`
 	SidecarServicePort      int64    `envconfig:"SIDECAR_SERVICE_PORT" default:"10110"`
-	UrlSigningSecret        string   `envconfig:"URL_SIGNING_SECRET"`
+	UrlSigningSecret        string   `envconfig:"URL_SIGNING_SECRET" default:"deadbeef"`
 	RasterCacheSize         int      `envconfig:"RASTER_CACHE_SIZE" default:"20"`
 	LoggingLevel            string   `envconfig:"LOGGING_LEVEL" default:"info"`
 }
@@ -269,6 +269,6 @@ func main() {
 
 	err = serveHttp(&config, fCache, ring, rasterCache, config.UrlSigningSecret, agent)
 	if err != nil {
-		panic(err.Error())
+		log.Fatalf("Failed to start HTTP server: %s", err)
 	}
 }


### PR DESCRIPTION
We decided it's best to make URL signing opt out (via `${RASTER_URL_SIGNING_ENABLED}`) rather than opt in, because it can bite us in the ass too easily otherwise.