### PR TITLE
Fix file cache cleanup again

### DIFF
--- a/docker/s6/services/.s6-svscan/crash
+++ b/docker/s6/services/.s6-svscan/crash
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+. $(dirname $0)/mark_for_cleanup.sh
+
 echo "Container crashed"

--- a/docker/s6/services/.s6-svscan/finish
+++ b/docker/s6/services/.s6-svscan/finish
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+. $(dirname $0)/mark_for_cleanup.sh
+
 echo "Container shutting down"

--- a/docker/s6/services/.s6-svscan/mark_for_cleanup.sh
+++ b/docker/s6/services/.s6-svscan/mark_for_cleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ # If ${RASTER_BASE_DIR} is volume mounted on the host, then we namespace
+# the cache folder using the current container ID (which can be read from
+# ${HOSTNAME}) and then we use the container_stopped file as a flag to
+# indicate whether we should clean the contents of any cache folders
+# from any previous containers when we start again on the same host.
+# The cleanup will be performed by lazyraster.svc
+if [ -d "${RASTER_BASE_DIR}/${HOSTNAME}" ]; then
+	touch "${RASTER_BASE_DIR}/${HOSTNAME}/container_stopped"
+fi

--- a/docker/s6/services/lazyraster.svc/run
+++ b/docker/s6/services/lazyraster.svc/run
@@ -1,8 +1,36 @@
 #!/bin/sh
 
 # Clean up cached files left behind by any previous containers using a background
-# job if ${RASTER_BASE_DIR} is volume mounted on the host
+# job if ${RASTER_BASE_DIR} is volume mounted on the host.
+# Note: This will *NOT* clean up cached files from the current container, in case
+# Lazyraster crashes and gets restarted by s6. This case is handled further below.
 if [ -d "${RASTER_BASE_DIR}" ]; then
+	(
+		# Select only the subfolders of ${RASTER_BASE_DIR}
+		for dir in "${RASTER_BASE_DIR}"/*/; do
+			# ${dir} will contain a trailing slash
+			if [ -f "${dir}container_stopped" ]; then
+				# First remove any temp files from the folder
+				find "${dir}" -mindepth 1 -type f ! -name "container_stopped" -delete && \
+				# Then remove the folder itself
+				rm -r "${dir}"
+			fi
+		done
+	) &
+else
+	echo "Error: Folder '${RASTER_BASE_DIR}' wasn't volume mounted on the host"
+	exit 1
+fi
+
+# Namespace the Lazyraster cache folder using the container ID, which we read from ${HOSTNAME}
+# This is needed because multiple Lazyraster containers can run on the same machine.
+export RASTER_BASE_DIR="${RASTER_BASE_DIR}/${HOSTNAME}"
+
+if [ ! -d "${RASTER_BASE_DIR}" ]; then
+	mkdir -p ${RASTER_BASE_DIR}
+else
+	# If lazyraster crashes, then s6 will restart it, so we need to clean up cached files
+	# left behind by the previous instance of Lazyraster.
 	NOW=$(date +%s)
 	(
 		# Delete old cached PDF files
@@ -14,15 +42,7 @@ if [ -d "${RASTER_BASE_DIR}" ]; then
 		#   process each directory's contents before the directory itself.
 		find "${RASTER_BASE_DIR}" -mindepth 1 -type d -empty \! -newermt "@${NOW}" -delete
 	) &
-else
-	echo "Error: Folder '${RASTER_BASE_DIR}' wasn't volume mounted on the host"
-	exit 1
 fi
-
-# Namespace the lazyraster cache folder using the container ID, which we read from ${HOSTNAME}
-# This is needed because multiple lazyraster containers can run on the same machine.
-export RASTER_BASE_DIR="${RASTER_BASE_DIR}/${HOSTNAME}"
-mkdir -p ${RASTER_BASE_DIR}
 
 echo "Launching Lazyraster service..."
 /lazyraster/lazyraster


### PR DESCRIPTION
Unfortunately, when #72 reverted #55, I didn't realise that the cleanup script will nuke cached files from other Lazyraster containers running on the same host, which is the reason that I created #55 in the first place...

As far as I can tell, the only way to satisfy both goals is to have two mechanisms for cleaning up cached files: One removes files left over from stopped containers and the other one removes files left over from crashed lazyraster processes from the same container.