### PR TITLE
Add datadog resource prefix if available

### DIFF
--- a/internal/transport/middleware.go
+++ b/internal/transport/middleware.go
@@ -161,6 +161,13 @@ func (m middleware) datadogTracer(next http.Handler) http.Handler {
 			resourceName = "unknown"
 		}
 		resourceName = r.Method + " " + resourceName
+
+		// If the header 'datadog-resource-prefix' is present the value will be prefixed at the resource name
+		// that is set at the span sent to Datadog.
+		resourcePrefix := r.Header.Get("datadog-resource-prefix")
+		if resourcePrefix != "" {
+			resourceName = fmt.Sprintf("%s - %s", resourcePrefix, resourceName)
+		}
 		span.SetTag(ext.ResourceName, resourceName)
 
 		status := ww.Status()


### PR DESCRIPTION
If the header 'datadog-resource-prefix' is present at the request then the value will be used at the datadog resource name.