### PR TITLE
Respect the bypass at the storage put

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	serviceCipher service.Cipher
 	serviceCache  service.Cache
 	serviceWorker service.Worker
+	serviceBypass service.Bypass
 }
 
 // Init the client internal state.
@@ -75,9 +76,12 @@ func (c *Client) Init() (err error) {
 		return fmt.Errorf("fail to initialize service cipher: %w", err)
 	}
 
+	c.serviceBypass.Service = c.serviceCipher
+
 	c.serviceWorker.URLSigningSecret = c.URLSigningSecret
 	c.serviceWorker.HTTPClient = httpClient
-	c.serviceWorker.Storage = service.Bypass{Service: c.serviceCipher}
+	c.serviceWorker.Storage = c.serviceBypass
+	c.serviceWorker.BypassStoragePut = c.serviceBypass
 	c.serviceWorker.Logger = c.Logger
 	c.serviceWorker.TraceExtractor = traceLogger(c.EnableDatadog)
 	c.serviceWorker.StorageBucketRegion = c.StorageBucketRegion

--- a/internal/service/bypass.go
+++ b/internal/service/bypass.go
@@ -22,7 +22,7 @@ type Bypass struct {
 
 // Get object.
 func (b Bypass) Get(ctx context.Context, key string) (_ io.ReadCloser, err error) {
-	if b.bypass(ctx) {
+	if b.Bypass(ctx) {
 		return nil, nil
 	}
 	return b.Service.Get(ctx, key)
@@ -30,13 +30,14 @@ func (b Bypass) Get(ctx context.Context, key string) (_ io.ReadCloser, err error
 
 // Put a object.
 func (b Bypass) Put(ctx context.Context, key string, payload io.Reader) (err error) {
-	if b.bypass(ctx) {
+	if b.Bypass(ctx) {
 		return nil
 	}
 	return b.Service.Put(ctx, key, payload)
 }
 
-func (Bypass) bypass(ctx context.Context) bool {
+// Bypass is used to indicate if the context has a flag to bypass a operation.
+func (Bypass) Bypass(ctx context.Context) bool {
 	bypass, _ := ctx.Value(BypassKey).(bool)
 	return bypass
 }


### PR DESCRIPTION
Because the storage put is using a different context as it's an async operation the storage put was not receiving the bypass flag to ignore the operation. This PR fixes this problem by adding a check before the storage put operation.