### PR TITLE
Reduce log output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	var (
-		logger                 = zerolog.New(os.Stdout).With().Timestamp().Caller().Logger()
+		logger                 = zerolog.New(os.Stdout).With().Timestamp().Caller().Logger().Level(zerolog.InfoLevel)
 		urlSigningSecret       = os.Getenv("URL_SIGNING_SECRET")
 		enableDatadog          = os.Getenv("ENABLE_DATADOG")
 		rawStorageBucketRegion = os.Getenv("STORAGE_BUCKET_REGION")

--- a/internal/transport/middleware.go
+++ b/internal/transport/middleware.go
@@ -83,7 +83,7 @@ func (m middleware) logger(next http.Handler) http.Handler {
 
 		t1 := time.Now()
 		reqID := chiMiddleware.GetReqID(r.Context())
-		entry := log.Info().
+		entry := log.Debug().
 			Str("requestID", reqID).
 			Str("method", r.Method).
 			Str("endpoint", requestURI).
@@ -111,7 +111,7 @@ func (m middleware) logger(next http.Handler) http.Handler {
 		next.ServeHTTP(ww, r)
 
 		status := ww.Status()
-		entry = log.Info().
+		entry = log.Debug().
 			Err(r.Context().Err()).
 			Str("requestID", reqID).
 			Dur("duration", time.Since(t1)).


### PR DESCRIPTION
Set the log level to info and the HTTP middleware logger to debug.