### PR TITLE
Add a parameter to allow the DPI to be changed dynamicaly

### DIFF
--- a/internal/service/worker_test.go
+++ b/internal/service/worker_test.go
@@ -186,7 +186,7 @@ func TestWorkerProcess(t *testing.T) {
 				getS3Client:         getS3Client,
 			}
 			require.NoError(t, w.Init())
-			err := w.Process(context.Background(), tt.url, tt.path, tt.page, tt.width, tt.scale, bytes.NewBuffer([]byte{}))
+			err := w.Process(context.Background(), tt.url, tt.path, tt.page, tt.width, tt.scale, 72, bytes.NewBuffer([]byte{}))
 			require.Equal(t, tt.expectedError == "", err == nil)
 			if tt.expectedError != "" {
 				require.Equal(t, tt.expectedError, err.Error())


### PR DESCRIPTION
lazypdf has a default value, that is 72 right now, and the client can choose between 72 and the 600, a hard limit created at lazyraster.

Issue: CW-1315