### PR TITLE
Add feature to render a given PDF page to HTML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,4 +64,4 @@ replace gopkg.in/DataDog/dd-trace-go.v1 v1.71.1 => gopkg.in/DataDog/dd-trace-go.
 
 // lazypdf version needs to be pinned as well because of the dd-trace-go version pinning which prevents the lazypdf version from being
 // updated.
-replace github.com/nitro/lazypdf/v2 v2.0.0-20250205120532-48aae54bfd96 => github.com/nitro/lazypdf/v2 v2.0.0-20250206115348-1829ea1fd728
+replace github.com/nitro/lazypdf/v2 v2.0.0-20250205120532-48aae54bfd96 => github.com/nitro/lazypdf/v2 v2.0.0-20250220163903-ee81e115f55e

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/nitro/lazypdf/v2 v2.0.0-20250206115348-1829ea1fd728 h1:lYbrSO6dULPPxdTBI/mwM+do3M7g1BtcNNtOYGleWA8=
-github.com/nitro/lazypdf/v2 v2.0.0-20250206115348-1829ea1fd728/go.mod h1:cAh1CSLNZXNh+PizhypjyoEyWz2cSjcGKe9EUBhEfxA=
+github.com/nitro/lazypdf/v2 v2.0.0-20250220163903-ee81e115f55e h1:kLF9QFyz/J2Kqowu3aU1u+ib/4PeaZwTDkkJ2L9fDHs=
+github.com/nitro/lazypdf/v2 v2.0.0-20250220163903-ee81e115f55e/go.mod h1:cAh1CSLNZXNh+PizhypjyoEyWz2cSjcGKe9EUBhEfxA=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -61,7 +61,7 @@ func (w *Worker) Init() error {
 }
 
 func (w *Worker) Process(
-	ctx context.Context, url, path string, page int, width int, scale float32, dpi int, output io.Writer,
+	ctx context.Context, url, path string, page int, width int, scale float32, dpi int, output io.Writer, format string,
 ) (err error) {
 	span, ctx := w.startSpan(ctx, "Worker.Process")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
@@ -103,10 +103,21 @@ func (w *Worker) Process(
 	}
 
 	storage := bytes.NewBuffer([]byte{})
-	//nolint:gosec,G115
-	err = lazypdf.SaveToPNG(ctx, uint16(page), uint16(width), scale, dpi, bytes.NewBuffer(payload), storage)
-	if err != nil {
-		return fmt.Errorf("fail to extract the PNG from the PDF: %w", err)
+	switch format {
+	case "png":
+		//nolint:gosec,G115
+		err = lazypdf.SaveToPNG(ctx, uint16(page), uint16(width), scale, dpi, bytes.NewBuffer(payload), storage)
+		if err != nil {
+			return fmt.Errorf("fail to extract the PNG from the PDF: %w", err)
+		}
+	case "html":
+		//nolint:gosec,G115
+		err = lazypdf.SaveToHTML(ctx, uint16(page), uint16(width), scale, dpi, bytes.NewBuffer(payload), storage)
+		if err != nil {
+			return fmt.Errorf("fail to render the PDF page to HTML: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown format '%s'", format)
 	}
 	result := io.NopCloser(storage)
 	defer result.Close()

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -19,7 +19,7 @@ type writer struct {
 	traceExtractor traceExtractor
 }
 
-func (wrt writer) response(ctx context.Context, w http.ResponseWriter, r interface{}, status int) {
+func (wrt writer) response(ctx context.Context, w http.ResponseWriter, r interface{}, status int, contentType string) {
 	logger, err := wrt.traceExtractor(ctx, wrt.logger)
 	if err != nil {
 		logger.Err(err).Msg("Fail to extract the tracing ids")
@@ -30,7 +30,7 @@ func (wrt writer) response(ctx context.Context, w http.ResponseWriter, r interfa
 		w.WriteHeader(status)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(status)
 
 	content, err := json.Marshal(r)
@@ -61,5 +61,5 @@ func (wrt writer) error(ctx context.Context, w http.ResponseWriter, title string
 	if err != nil {
 		resp.Error.Detail = err.Error()
 	}
-	wrt.response(ctx, w, &resp, status)
+	wrt.response(ctx, w, &resp, status, "application/json")
 }


### PR DESCRIPTION
A new query string option was added to the '/documents' endoint called format. By default it's value is 'png', but it can also be 'html', which will trigger the rendering of the page to HTML.

Issue: CW-1505