### PR TITLE
Add token-ttl to the acceptable list of params to be verified

### DIFF
--- a/internal/transport/handler.go
+++ b/internal/transport/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -183,7 +184,7 @@ func (h handler) metadata(w http.ResponseWriter, r *http.Request) {
 func (handler) urlToVerify(r *http.Request) string {
 	q := r.URL.Query()
 	for key := range q {
-		if key == "page" || key == "token" {
+		if slices.Contains([]string{"page", "token", "token-ttl"}, key) {
 			continue
 		}
 		q.Del(key)

--- a/internal/transport/handler_test.go
+++ b/internal/transport/handler_test.go
@@ -33,6 +33,10 @@ func TestHandlerURLToVerify(t *testing.T) {
 			path:     "/path?page=1&token=2&scale=3&width=4",
 			expected: "/path?page=1&token=2",
 		},
+		{
+			path:     "/path?page=1&token=2&scale=3&width=4&token-ttl=5",
+			expected: "/path?page=1&token=2&token-ttl=5",
+		},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("Scenario %d", i), func(t *testing.T) {


### PR DESCRIPTION
The service does a filter on the params and only pass to the token validation the ones that were signed by lazy-raster-links. Since 'token-ttl' was recently added to lazy-raster-links, it should be added to lazyraster as well.

Issue: CW-1881