### PR TITLE
CW-2450 - Improve SavePDF Performance in Core PDF Handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/nitro/lazypdf/v2 v2.0.0-20250710155429-666f38ca729e
+	github.com/nitro/lazypdf/v2 v2.0.0-20250725100611-4b50ece4033a
 	github.com/rs/zerolog v1.34.0
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nitro/lazypdf/v2 v2.0.0-20250710155429-666f38ca729e h1:yqnCdtlMHDgfstOHFyCdOPst3tdMH1tJVOZlZO8BN2g=
-github.com/nitro/lazypdf/v2 v2.0.0-20250710155429-666f38ca729e/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
+github.com/nitro/lazypdf/v2 v2.0.0-20250725100611-4b50ece4033a h1:bwlTDokf06Im6JLlJvhMtKcqIkPrThUgMI//c5bGY9k=
+github.com/nitro/lazypdf/v2 v2.0.0-20250725100611-4b50ece4033a/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0 h1:n0nWcGanaHanlih+YRp8etj1/fYZoQFRk+7+/J85dpU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0/go.mod h1:MMvJIC26DIEZo5DR4Ub/WJD1aPVxKGpgJolXxTtjgLE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.122.0 h1:zuqwUU8P+IqQMHvMYHlTBXt8lRn1Zu2B9QNAscLP+9A=

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -379,7 +379,9 @@ func (w *Worker) extractToken(endpoint string) (string, error) {
 // fetchAnnotations is used to get the annotations based on a token and preprocess them. The second return parameter is
 // a cleanup function that always need to be executed once the information is no longer needed. The cleanup function is
 // only available in case there is no errors.
-func (w *Worker) fetchAnnotations(ctx context.Context, token string, page int) (annotations []any, cleanup func(), err error) {
+func (w *Worker) fetchAnnotations(
+	ctx context.Context, token string, page int,
+) (annotations []any, cleanup func(), err error) {
 	span, ctx := ddTracer.StartSpanFromContext(ctx, "Worker.fetchAnnotations")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
@@ -447,7 +449,9 @@ func (w *Worker) fetchAnnotations(ctx context.Context, token string, page int) (
 	return annotations, cleanup, nil
 }
 
-func (w *Worker) processAnnotations(payload io.Reader, annotations []any, page int) (filePath string, cleanup func(), err error) {
+func (w *Worker) processAnnotations(
+	payload io.Reader, annotations []any, page int,
+) (filePath string, cleanup func(), err error) {
 	span, ctx := ddTracer.StartSpanFromContext(context.Background(), "Worker.processAnnotations")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -144,7 +144,7 @@ func (w *Worker) Process(
 
 		var payload io.Reader
 		if len(annotations) > 0 {
-			result, resultCleanup, err := w.processAnnotations(bytes.NewBuffer(rawPayload), annotations, page)
+			result, resultCleanup, err := w.processAnnotations(ctx, bytes.NewBuffer(rawPayload), annotations, page)
 			if err != nil {
 				return fmt.Errorf("failed to process the annotations: %w", err)
 			}
@@ -450,9 +450,12 @@ func (w *Worker) fetchAnnotations(
 }
 
 func (w *Worker) processAnnotations(
-	payload io.Reader, annotations []any, page int,
+	ctx context.Context, payload io.Reader, annotations []any, page int,
 ) (filePath string, cleanup func(), err error) {
-	span, ctx := ddTracer.StartSpanFromContext(context.Background(), "Worker.processAnnotations")
+	span, ctx := ddTracer.StartSpanFromContext(ctx, "Worker.processAnnotationsTest")
+	span.Finish(ddTracer.WithError(err))
+
+	span, ctx = ddTracer.StartSpanFromContext(ctx, "Worker.processAnnotations")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
 	ph := lazypdf.PdfHandler{}

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -477,7 +477,6 @@ func (w *Worker) processAnnotations(
 		var annSpan ddtrace.Span
 		switch v := annotation.(type) {
 		case domain.AnnotationCheckbox:
-			annSpan, _ = ddTracer.StartSpanFromContext(ctx, "PdfHandler.AddCheckboxToPage")
 			params := lazypdf.CheckboxParams{
 				Value: v.Value,
 				Page:  v.Page - 1,
@@ -491,12 +490,12 @@ func (w *Worker) processAnnotations(
 				},
 			}
 			if page != params.Page {
-				annSpan.Finish()
 				continue
 			}
+			annSpan, _ = ddTracer.StartSpanFromContext(ctx, "PdfHandler.AddCheckboxToPage")
 			err = ph.AddCheckboxToPage(doc, params)
+			annSpan.Finish(ddTracer.WithError(err))
 		case domain.AnnotationImage:
-			annSpan, _ = ddTracer.StartSpanFromContext(ctx, "PdfHandler.AddImageToPage")
 			params := lazypdf.ImageParams{
 				Page: v.Page - 1,
 				Location: lazypdf.Location{
@@ -510,12 +509,12 @@ func (w *Worker) processAnnotations(
 				ImagePath: v.ImageLocation,
 			}
 			if page != params.Page {
-				annSpan.Finish()
 				continue
 			}
+			annSpan, _ = ddTracer.StartSpanFromContext(ctx, "PdfHandler.AddImageToPage")
 			err = ph.AddImageToPage(doc, params)
+			annSpan.Finish(ddTracer.WithError(err))
 		case domain.AnnotationText:
-			annSpan, _ = ddTracer.StartSpanFromContext(ctx, "PdfHandler.AddTextBoxToPage")
 			params := lazypdf.TextParams{
 				Value: v.Value,
 				Page:  v.Page - 1,
@@ -536,14 +535,14 @@ func (w *Worker) processAnnotations(
 				},
 			}
 			if page != params.Page {
-				annSpan.Finish()
 				continue
 			}
+			annSpan, _ = ddTracer.StartSpanFromContext(ctx, "PdfHandler.AddTextBoxToPage")
 			err = ph.AddTextBoxToPage(doc, params)
+			annSpan.Finish(ddTracer.WithError(err))
 		default:
 			return "", nil, fmt.Errorf("annotation type '%T' not supported", annotation)
 		}
-		annSpan.Finish(ddTracer.WithError(err))
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to add an annotation to the PDF: %w", err)
 		}


### PR DESCRIPTION
## Links
https://gonitro.atlassian.net/browse/CW-2450
https://github.com/Nitro/lazyraster/pull/360

## Description
The current SavePDF implementation uses aggressive compression and full garbage collection, which results in:

- On faulty.pdf
  - Save time improved from ~727 ms → ~49 ms (~14× faster)
  - Memory reduced from ~500 B/op → ~77 B/op (~6.5× less)
- On other files
  - Save time: Improved slightly (~2–8%)
  - Save time: Slightly slower in some cases (~1.5–3%)

This change significantly improves worst-case performance while maintaining or slightly improving average-case speed and memory usage. 