### PR TITLE
CW-2477 - Optimize wrapPageContents to avoid redundant analysis on each annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/nitro/lazypdf/v2 v2.0.0-20250729142805-fab11744de15
+	github.com/nitro/lazypdf/v2 v2.0.0-20250730083528-d0d03efe46d5
 	github.com/rs/zerolog v1.34.0
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/nitro/lazypdf/v2 v2.0.0-20250730083528-d0d03efe46d5
+	github.com/nitro/lazypdf/v2 v2.0.0-20250730104516-8a96d6c9d587
 	github.com/rs/zerolog v1.34.0
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/nitro/lazypdf/v2 v2.0.0-20250730104516-8a96d6c9d587
+	github.com/nitro/lazypdf/v2 v2.0.0-20250730155052-b38888b0d35a
 	github.com/rs/zerolog v1.34.0
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nitro/lazypdf/v2 v2.0.0-20250730083528-d0d03efe46d5 h1:fQrruA7yDTixFfl5vkZD50NJESDpGhccWoZB8qod74Q=
-github.com/nitro/lazypdf/v2 v2.0.0-20250730083528-d0d03efe46d5/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
+github.com/nitro/lazypdf/v2 v2.0.0-20250730104516-8a96d6c9d587 h1:EkXJpHFBoOqSrT6ezb2QWh3aNgpVCH3/myjfJJ/I94Q=
+github.com/nitro/lazypdf/v2 v2.0.0-20250730104516-8a96d6c9d587/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0 h1:n0nWcGanaHanlih+YRp8etj1/fYZoQFRk+7+/J85dpU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0/go.mod h1:MMvJIC26DIEZo5DR4Ub/WJD1aPVxKGpgJolXxTtjgLE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.122.0 h1:zuqwUU8P+IqQMHvMYHlTBXt8lRn1Zu2B9QNAscLP+9A=

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nitro/lazypdf/v2 v2.0.0-20250730104516-8a96d6c9d587 h1:EkXJpHFBoOqSrT6ezb2QWh3aNgpVCH3/myjfJJ/I94Q=
-github.com/nitro/lazypdf/v2 v2.0.0-20250730104516-8a96d6c9d587/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
+github.com/nitro/lazypdf/v2 v2.0.0-20250730155052-b38888b0d35a h1:C4yYK/6Yn9t5fcDMZqCeIAXKjvyDpVI/4rzuT89ZCbY=
+github.com/nitro/lazypdf/v2 v2.0.0-20250730155052-b38888b0d35a/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0 h1:n0nWcGanaHanlih+YRp8etj1/fYZoQFRk+7+/J85dpU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0/go.mod h1:MMvJIC26DIEZo5DR4Ub/WJD1aPVxKGpgJolXxTtjgLE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.122.0 h1:zuqwUU8P+IqQMHvMYHlTBXt8lRn1Zu2B9QNAscLP+9A=

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nitro/lazypdf/v2 v2.0.0-20250729142805-fab11744de15 h1:vScNAEyATbvwI8Y1RyKak3YESf5885S/IB+FV0734jk=
-github.com/nitro/lazypdf/v2 v2.0.0-20250729142805-fab11744de15/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
+github.com/nitro/lazypdf/v2 v2.0.0-20250730083528-d0d03efe46d5 h1:fQrruA7yDTixFfl5vkZD50NJESDpGhccWoZB8qod74Q=
+github.com/nitro/lazypdf/v2 v2.0.0-20250730083528-d0d03efe46d5/go.mod h1:hIq0I7f/dyOQlD8RP0wFK57BCgKiFZxl9uO9jeso2y8=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0 h1:n0nWcGanaHanlih+YRp8etj1/fYZoQFRk+7+/J85dpU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0/go.mod h1:MMvJIC26DIEZo5DR4Ub/WJD1aPVxKGpgJolXxTtjgLE=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.122.0 h1:zuqwUU8P+IqQMHvMYHlTBXt8lRn1Zu2B9QNAscLP+9A=

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -470,7 +470,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 		return fmt.Errorf("failed to open the PDF: %w", err)
 	}
 	defer func() {
-		if err := ph.ClosePDF(doc); err != nil {
+		if err := ph.ClosePDF(&doc); err != nil {
 			w.Logger.Err(err).Msg("Failed to close the PDF")
 		}
 	}()
@@ -497,7 +497,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 					Height: v.Size.Height,
 				},
 			}
-			err = ph.AddCheckboxToPage(doc, params)
+			err = ph.AddCheckboxToPage(&doc, params)
 		case domain.AnnotationImage:
 			params := lazypdf.ImageParams{
 				Page: v.Page - 1,
@@ -511,7 +511,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 				},
 				ImagePath: v.ImageLocation,
 			}
-			err = ph.AddImageToPage(doc, params)
+			err = ph.AddImageToPage(&doc, params)
 		case domain.AnnotationText:
 			params := lazypdf.TextParams{
 				Value: v.Value,
@@ -532,7 +532,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 					Height: v.Size.Height,
 				},
 			}
-			err = ph.AddTextBoxToPage(doc, params)
+			err = ph.AddTextBoxToPage(&doc, params)
 		default:
 			return fmt.Errorf("annotation type '%T' not supported", annotation)
 		}
@@ -541,6 +541,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 		}
 	}
 
+	//nolint:govet
 	err = ph.SaveToPNG(doc, page, width, scale, dpi, storage)
 	if err != nil {
 		return fmt.Errorf("failed to add an annotation to the PDF: %w", err)

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -470,7 +470,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 		return fmt.Errorf("failed to open the PDF: %w", err)
 	}
 	defer func() {
-		if err := ph.ClosePDF(&doc); err != nil {
+		if err := ph.ClosePDF(doc); err != nil {
 			w.Logger.Err(err).Msg("Failed to close the PDF")
 		}
 	}()
@@ -497,7 +497,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 					Height: v.Size.Height,
 				},
 			}
-			err = ph.AddCheckboxToPage(&doc, params)
+			err = ph.AddCheckboxToPage(doc, params)
 		case domain.AnnotationImage:
 			params := lazypdf.ImageParams{
 				Page: v.Page - 1,
@@ -511,7 +511,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 				},
 				ImagePath: v.ImageLocation,
 			}
-			err = ph.AddImageToPage(&doc, params)
+			err = ph.AddImageToPage(doc, params)
 		case domain.AnnotationText:
 			params := lazypdf.TextParams{
 				Value: v.Value,
@@ -532,7 +532,7 @@ func (w *Worker) SaveToPNGWithAnnotations(
 					Height: v.Size.Height,
 				},
 			}
-			err = ph.AddTextBoxToPage(&doc, params)
+			err = ph.AddTextBoxToPage(doc, params)
 		default:
 			return fmt.Errorf("annotation type '%T' not supported", annotation)
 		}
@@ -541,7 +541,6 @@ func (w *Worker) SaveToPNGWithAnnotations(
 		}
 	}
 
-	//nolint:govet
 	err = ph.SaveToPNG(doc, page, width, scale, dpi, storage)
 	if err != nil {
 		return fmt.Errorf("failed to add an annotation to the PDF: %w", err)


### PR DESCRIPTION
## Links
https://gonitro.atlassian.net/browse/CW-2477
https://github.com/Nitro/lazyraster/pull/366

## Description

Currently, each call to AddAnnotation (e.g., AddText, AddImage, AddCheckbox) triggers a call to wrapPageContents, which performs a costly analysis to rebalance the graphic states of the page. 
While this is necessary once, doing it repeatedly causes significant performance degradation especially on large documents.

- `go get github.com/nitro/lazypdf/v2@main`