### PR TITLE
luke/CW-3316 remove dropbox lazyraster

### DIFF
--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -211,10 +210,6 @@ func (w *Worker) fetchFile(ctx context.Context, path string) (_ []byte, err erro
 	span, ctx := ddTracer.StartSpanFromContext(ctx, "Worker.fetchFile")
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
-	if strings.HasPrefix(path, "dropbox/") {
-		return w.fetchFileFromDropbox(ctx, path)
-	}
-
 	var bucket, filePath string
 	switch {
 	case strings.HasPrefix(path, "s3://"):
@@ -259,40 +254,6 @@ func (w *Worker) fetchFile(ctx context.Context, path string) (_ []byte, err erro
 		return nil, fmt.Errorf("fail to read the reader: %w", err)
 	}
 	span.SetTag("fileSize", len(payload))
-
-	return payload, nil
-}
-
-func (w *Worker) fetchFileFromDropbox(ctx context.Context, path string) (_ []byte, err error) {
-	span, ctx := ddTracer.StartSpanFromContext(ctx, "Worker.fetchFileFromDropbox")
-	defer func() { span.Finish(ddTracer.WithError(err)) }()
-
-	fileURL, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(path, "dropbox/"))
-	if err != nil {
-		return nil, newClientError(fmt.Errorf("fail to decode base64 path: %w", err))
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, string(fileURL), nil)
-	if err != nil {
-		return nil, fmt.Errorf("fail to create the HTTP request: %w", err)
-	}
-
-	resp, err := w.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fail to download file: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, newNotFoundError(errors.New("dropbox returned 404"))
-	} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("invalid status code '%d'", resp.StatusCode)
-	}
-
-	payload, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("fail to read the body response: %w", err)
-	}
 
 	return payload, nil
 }

--- a/internal/transport/middleware.go
+++ b/internal/transport/middleware.go
@@ -71,9 +71,6 @@ func (m middleware) logger(next http.Handler) http.Handler {
 		if token := r.URL.Query().Get("token"); token != "" {
 			requestURI = strings.ReplaceAll(requestURI, token, "[REDACTED]")
 		}
-		if strings.HasPrefix(requestURI, "/documents/dropbox/") {
-			requestURI = "/documents/dropbox/[REDACTED]"
-		}
 
 		log, err := m.traceExtractor(r.Context(), m.log)
 		if err != nil {
@@ -135,9 +132,6 @@ func (m middleware) logger(next http.Handler) http.Handler {
 func (m middleware) datadogTracer(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if strings.HasPrefix(path, "/documents/dropbox/") {
-			path = "/documents/dropbox/[REDACTED]"
-		}
 
 		opts := []ddtrace.StartSpanOption{
 			tracer.SpanType(ext.SpanTypeWeb),

--- a/internal/transport/server.go
+++ b/internal/transport/server.go
@@ -98,6 +98,5 @@ func (s *Server) initHandler() {
 	s.router.MethodNotAllowed(h.methodNotAllowed)
 	s.router.NotFound(h.notFound)
 	s.router.Get("/health", h.health)
-	s.router.Get("/documents/dropbox/*", h.document)
 	s.router.Get("/documents/*", h.document)
 }


### PR DESCRIPTION
Drop route /documents/dropbox/*, worker fetch path, and middleware redaction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the `/documents/dropbox/*` endpoint and the worker’s `dropbox/` fetch path, which can break existing clients or integrations relying on Dropbox-backed documents. Changes are localized but impact externally visible routing and document retrieval behavior.
> 
> **Overview**
> This PR **removes Dropbox-backed document handling** across the service.
> 
> The `/documents/dropbox/*` route is dropped, the worker no longer recognizes `dropbox/` paths (and deletes the `fetchFileFromDropbox` base64-decoded HTTP download flow), and middleware logging/tracing no longer special-cases/redacts Dropbox document URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b139fa31c1445948e586d4caa3719f32c31012a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->