### PR TITLE
Degrade gracefully when the annotation store is unavailable

### DIFF
--- a/internal/repository/redis.go
+++ b/internal/repository/redis.go
@@ -40,6 +40,18 @@ func NewRedisClient(addr, username, password string) (RedisClient, error) {
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},
+		// Bound each connection stage so a failover (the primary endpoint is briefly unreachable
+		// while a replica is promoted) or a slow node fails fast and the client reconnects, rather
+		// than hanging until the caller's request deadline is exceeded. MaxRetries lets go-redis
+		// re-establish the connection to the new primary transparently. Conservative starting
+		// points; tune against production latency.
+		DialTimeout:     2 * time.Second,
+		ReadTimeout:     time.Second,
+		WriteTimeout:    time.Second,
+		PoolTimeout:     2 * time.Second,
+		MaxRetries:      2,
+		MinRetryBackoff: 20 * time.Millisecond,
+		MaxRetryBackoff: 200 * time.Millisecond,
 	})
 	ctx, ctxcancel := context.WithTimeout(context.Background(), time.Second)
 	defer ctxcancel()

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -354,9 +354,21 @@ func (w *Worker) fetchAnnotations(
 	defer func() { span.Finish(ddTracer.WithError(err)) }()
 
 	annotations = make([]any, 0)
+	if w.AnnotationStorage == nil {
+		return annotations, func() {}, nil
+	}
 	originalAnnotations, err := w.AnnotationStorage.FetchAnnotation(ctx, token)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to fetch the annotations: %w", err)
+		// Degrade gracefully: a Redis read failure (for example a failover while a replica is
+		// promoted, or a node blip) must not fail the whole render. Render the page without
+		// annotations instead of returning a 500. Logged and span-tagged so the degradation stays
+		// visible and alertable.
+		span.SetTag("annotations.storage_degraded", true)
+		w.Logger.Warn().
+			Err(err).
+			Int("page", page).
+			Msg("failed to fetch annotations; rendering page without annotations")
+		return annotations, func() {}, nil
 	}
 
 	var temporaryAnnotationFilesMutex sync.Mutex

--- a/internal/service/worker_test.go
+++ b/internal/service/worker_test.go
@@ -260,10 +260,11 @@ func TestWorkerProcess(t *testing.T) {
 	}
 }
 
-// TestWorkerProcessNoGoroutineLeak is a regression test for a goroutine + heap leak in Process. The file is fetched in
-// a goroutine that sends the payload over a channel. When Process returns early on the png path (here, because
-// fetchAnnotations fails) before draining that channel, the goroutine must still be able to complete its send and
-// exit. With unbuffered channels it would block forever, leaking the goroutine and the payload it holds.
+// TestWorkerProcessNoGoroutineLeak is a regression test for a goroutine + heap leak in Process. The file is fetched
+// in a goroutine that sends the payload over a buffered channel. When Process returns early (here, because the
+// requested format is unknown) after the fetch goroutine has started but before draining that channel, the goroutine
+// must still be able to complete its send and exit. With unbuffered channels it would block forever, leaking the
+// goroutine and the payload it holds.
 func TestWorkerProcessNoGoroutineLeak(t *testing.T) {
 	urlSecret := "secret"
 	validToken := urlsign.GenerateToken(urlSecret, 8*time.Hour, time.Now().Add(time.Hour), "documents")
@@ -275,17 +276,12 @@ func TestWorkerProcessNoGoroutineLeak(t *testing.T) {
 	// caller; a plain fake avoids sharing a single drained buffer across goroutines.
 	s3Client := fakeS3{payload: payload}
 
-	var annotationStorage mockWorkerAnnotationStorage
-	annotationStorage.On("FetchAnnotation", mock.Anything, mock.Anything).
-		Return([]any(nil), errors.New("annotation storage is down"))
-
 	w := Worker{
 		HTTPClient:          http.DefaultClient,
 		URLSigningSecret:    urlSecret,
 		TraceExtractor:      traceExtractor,
 		StorageBucketRegion: map[string]string{"bucket-1": "eu-central-1"},
 		getS3Client:         func(string) (workerS3API, error) { return s3Client, nil },
-		AnnotationStorage:   &annotationStorage,
 	}
 	require.NoError(t, w.Init())
 
@@ -296,8 +292,10 @@ func TestWorkerProcessNoGoroutineLeak(t *testing.T) {
 	const iterations = 50
 	url := fmt.Sprintf("documents?token=%s", validToken)
 	for range iterations {
+		// An unknown format returns on the switch's default case: after the fetch goroutine has started but before
+		// the channel is drained — the exact early-return path that previously leaked with unbuffered channels.
 		err := w.Process(
-			context.Background(), url, "bucket-1/file.pdf", 1, 0, 0, 72, bytes.NewBuffer([]byte{}), "png",
+			context.Background(), url, "bucket-1/file.pdf", 1, 0, 0, 72, bytes.NewBuffer([]byte{}), "unknown-format",
 		)
 		require.Error(t, err)
 	}
@@ -308,6 +306,39 @@ func TestWorkerProcessNoGoroutineLeak(t *testing.T) {
 		return runtime.NumGoroutine() <= baseline+5
 	}, 5*time.Second, 20*time.Millisecond,
 		"goroutines did not return to baseline (leak): baseline=%d current=%d", baseline, runtime.NumGoroutine())
+}
+
+// TestWorkerProcessDegradesWhenAnnotationFetchFails verifies that a failing annotation store (for example Redis
+// during a failover) does not fail the render: Process returns no error and still produces a page, just without the
+// baked annotations.
+func TestWorkerProcessDegradesWhenAnnotationFetchFails(t *testing.T) {
+	urlSecret := "secret"
+	validToken := urlsign.GenerateToken(urlSecret, 8*time.Hour, time.Now().Add(time.Hour), "documents")
+
+	payload, err := os.ReadFile("testdata/sample.pdf")
+	require.NoError(t, err)
+
+	var annotationStorage mockWorkerAnnotationStorage
+	annotationStorage.On("FetchAnnotation", mock.Anything, mock.Anything).
+		Return([]any(nil), errors.New("annotation storage is down"))
+
+	w := Worker{
+		HTTPClient:          http.DefaultClient,
+		URLSigningSecret:    urlSecret,
+		TraceExtractor:      traceExtractor,
+		StorageBucketRegion: map[string]string{"bucket-1": "eu-central-1"},
+		getS3Client:         func(string) (workerS3API, error) { return fakeS3{payload: payload}, nil },
+		AnnotationStorage:   &annotationStorage,
+	}
+	require.NoError(t, w.Init())
+
+	output := bytes.NewBuffer([]byte{})
+	url := fmt.Sprintf("documents?token=%s", validToken)
+	err = w.Process(context.Background(), url, "bucket-1/file.pdf", 1, 0, 0, 72, output, "png")
+
+	require.NoError(t, err)
+	require.NotEmpty(t, output.Bytes())
+	annotationStorage.AssertCalled(t, "FetchAnnotation", mock.Anything, mock.Anything)
 }
 
 // fakeS3 returns a fresh reader over payload on every call so concurrent fetches don't share a drained buffer.


### PR DESCRIPTION
## Why

A failure reading annotations from Redis (`FetchAnnotation`) currently fails the entire PNG render with an HTTP 500 on `GET /documents/*`. A transient Redis problem — a failover while a replica is promoted, or a slow/unreachable node — shouldn't take down page rendering; the annotations are an overlay, not the page itself.

## What

- **Graceful degradation** (`internal/service/worker.go`): a `FetchAnnotation` error — or a nil/disabled store (which previously would have panicked) — now renders the page **without** annotations and records the degradation (WARN log + `annotations.storage_degraded` span tag) instead of returning a 500. A Redis miss (`redis.Nil`) was already treated as "no annotations".
- **More resilient Redis client** (`internal/repository/redis.go`): explicit `DialTimeout` / `ReadTimeout` / `WriteTimeout` / `PoolTimeout` + bounded `MaxRetries`/backoff, so the client reconnects promptly after a failover rather than hanging until the caller's request deadline is exceeded.
- **Tests**: new `TestWorkerProcessDegradesWhenAnnotationFetchFails`; the existing goroutine-leak regression is retargeted to the unknown-format early-return path (its previous annotation-error trigger now degrades gracefully, so it no longer returns early there).

## Review notes

- This favours **availability over completeness**: during a Redis problem a page renders **without baked annotations**. It's surfaced via a WARN log and the `annotations.storage_degraded` span tag — worth alerting on so the degradation stays visible.
- The Redis timeout/retry values are conservative starting points; validate under production latency.

Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
