### PR TITLE
Bound concurrent renders to prevent OOMKilled pods (503s)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -34,16 +35,22 @@ func main() {
 		logger.Fatal().Msg("Fail to parse the environment variable 'STORAGE_BUCKET_REGION' payload")
 	}
 
+	maxConcurrentRenders, err := parseMaxConcurrentRenders(os.Getenv("MAX_CONCURRENT_RENDERS"))
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Fail to parse the environment variable 'MAX_CONCURRENT_RENDERS'")
+	}
+
 	waitHandlerAsyncError, waitHandler := wait(logger)
 	client := internal.Client{
-		Logger:              logger,
-		AsyncErrorHandler:   waitHandlerAsyncError,
-		URLSigningSecret:    urlSigningSecret,
-		EnableDatadog:       enableDatadog == "true",
-		StorageBucketRegion: storageBucketRegion,
-		RedisURL:            os.Getenv("REDIS_URL"),
-		RedisUsername:       os.Getenv("REDIS_USERNAME"),
-		RedisPassword:       os.Getenv("REDIS_PASSWORD"),
+		Logger:               logger,
+		AsyncErrorHandler:    waitHandlerAsyncError,
+		URLSigningSecret:     urlSigningSecret,
+		EnableDatadog:        enableDatadog == "true",
+		StorageBucketRegion:  storageBucketRegion,
+		RedisURL:             os.Getenv("REDIS_URL"),
+		RedisUsername:        os.Getenv("REDIS_USERNAME"),
+		RedisPassword:        os.Getenv("REDIS_PASSWORD"),
+		MaxConcurrentRenders: maxConcurrentRenders,
 	}
 	if err := client.Init(); err != nil {
 		logger.Fatal().Err(err).Msg("Fail to initialize the client")
@@ -74,6 +81,22 @@ func wait(logger zerolog.Logger) (func(error), func() int) {
 		return (int)(exitStatus)
 	}
 	return asyncError, handler
+}
+
+// parseMaxConcurrentRenders reads the optional MAX_CONCURRENT_RENDERS override. An empty value means
+// "unset" and returns 0, which lets the service worker fall back to its GOMAXPROCS-derived default.
+func parseMaxConcurrentRenders(payload string) (int, error) {
+	if payload == "" {
+		return 0, nil
+	}
+	value, err := strconv.Atoi(payload)
+	if err != nil {
+		return 0, fmt.Errorf("must be an integer: %w", err)
+	}
+	if value < 1 {
+		return 0, fmt.Errorf("must be greater than zero, got %d", value)
+	}
+	return value, nil
 }
 
 func parseStorageBucketRegion(payload string) (map[string]string, error) {

--- a/internal/client.go
+++ b/internal/client.go
@@ -27,7 +27,10 @@ type Client struct {
 	RedisURL            string
 	RedisUsername       string
 	RedisPassword       string
-	redisDisabled       bool
+	// MaxConcurrentRenders bounds concurrent rasterization per pod to keep peak memory under the
+	// container limit; see service.Worker.MaxConcurrentRenders. Zero uses the worker's default.
+	MaxConcurrentRenders int
+	redisDisabled        bool
 
 	server        transport.Server
 	serviceWorker service.Worker
@@ -93,6 +96,7 @@ func (c *Client) Init() (err error) {
 	c.serviceWorker.Logger = c.Logger
 	c.serviceWorker.TraceExtractor = traceLogger(c.EnableDatadog)
 	c.serviceWorker.StorageBucketRegion = c.StorageBucketRegion
+	c.serviceWorker.MaxConcurrentRenders = c.MaxConcurrentRenders
 	if err := c.serviceWorker.Init(); err != nil {
 		return fmt.Errorf("fail to initialize service worker: %w", err)
 	}

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -37,6 +38,12 @@ type workerAnnotationStorage interface {
 	FetchAnnotation(context.Context, string) ([]any, error)
 }
 
+// defaultRendersPerCPU derives Worker.MaxConcurrentRenders from the CPU budget when it is not set
+// explicitly. Rasterization is CPU-bound in the lazypdf C layer, so scaling with GOMAXPROCS keeps the
+// bound sensible across pod sizes; the multiplier lets a file fetch overlap an in-flight render
+// without letting concurrent renders grow without limit.
+const defaultRendersPerCPU = 2
+
 // Worker used to fetch and process PDF files.
 type Worker struct {
 	HTTPClient          *http.Client
@@ -46,8 +53,16 @@ type Worker struct {
 	StorageBucketRegion map[string]string
 	AnnotationStorage   workerAnnotationStorage
 
+	// MaxConcurrentRenders bounds how many rasterization operations may run on this worker at once.
+	// Rasterizing a PDF holds the whole source file and the rendered output in memory and triggers
+	// allocations in the lazypdf C layer that GOMEMLIMIT cannot account for, so without a cap a burst
+	// of large or complex documents can drive the pod past its memory limit and get it OOMKilled,
+	// which surfaces to callers as 503s. Values <= 0 fall back to a GOMAXPROCS-derived default in Init.
+	MaxConcurrentRenders int
+
 	getS3Client func(string) (workerS3API, error)
 	s3Clients   map[string]workerS3API
+	renderSem   chan struct{}
 	mutex       sync.Mutex
 }
 
@@ -69,7 +84,29 @@ func (w *Worker) Init() error {
 		w.getS3Client = w.getBucketS3Client
 	}
 	w.s3Clients = make(map[string]workerS3API)
+
+	if w.MaxConcurrentRenders <= 0 {
+		w.MaxConcurrentRenders = runtime.GOMAXPROCS(0) * defaultRendersPerCPU
+	}
+	w.renderSem = make(chan struct{}, w.MaxConcurrentRenders)
 	return nil
+}
+
+// acquireRenderSlot blocks until a rasterization slot is available or ctx is done, bounding the
+// number of concurrent renders (see Worker.MaxConcurrentRenders) so a single pod cannot allocate more
+// memory than its limit allows and get OOMKilled. The returned release function frees the slot and
+// must always be called once rendering is complete. When ctx is cancelled or times out before a slot
+// frees, it returns the context error and no slot is held.
+func (w *Worker) acquireRenderSlot(ctx context.Context) (release func(), err error) {
+	span, ctx := ddTracer.StartSpanFromContext(ctx, "internal/service/Worker.acquireRenderSlot")
+	defer func() { span.Finish(ddTracer.WithError(err)) }()
+
+	select {
+	case w.renderSem <- struct{}{}:
+		return func() { <-w.renderSem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (w *Worker) Process(
@@ -104,6 +141,14 @@ func (w *Worker) Process(
 	if !urlsign.IsValidSignature(w.URLSigningSecret, 8*time.Hour, time.Now(), url) {
 		return newClientError(errors.New("invalid token"))
 	}
+
+	// Bound concurrent rasterization before pulling the file into memory, so a burst of requests can't
+	// stack their payloads and renders past the pod's memory limit and trigger an OOMKill.
+	releaseRenderSlot, err := w.acquireRenderSlot(ctx)
+	if err != nil {
+		return fmt.Errorf("fail to acquire a render slot: %w", err)
+	}
+	defer releaseRenderSlot()
 
 	// Fetch the file in a goroutine to allow the annotations to be processed while the payload is being fetch. The
 	// channels are buffered so the goroutine can always complete its single send and exit, even when Process returns
@@ -212,6 +257,14 @@ func (w *Worker) Render(
 	if dpi < 0 || dpi > 600 {
 		return newClientError(fmt.Errorf("invalid dpi %d, must be between 0 and 600", dpi))
 	}
+
+	// Bound concurrent rasterization before pulling the file into memory, so a burst of requests can't
+	// stack their payloads and renders past the pod's memory limit and trigger an OOMKill.
+	releaseRenderSlot, err := w.acquireRenderSlot(ctx)
+	if err != nil {
+		return fmt.Errorf("fail to acquire a render slot: %w", err)
+	}
+	defer releaseRenderSlot()
 
 	payload, err := w.fetchFile(ctx, path)
 	if err != nil {

--- a/internal/service/worker_test.go
+++ b/internal/service/worker_test.go
@@ -352,6 +352,56 @@ func TestWorkerRenderInvalidPage(t *testing.T) {
 	require.ErrorIs(t, err, ErrClient)
 }
 
+// TestWorkerInitDefaultsMaxConcurrentRenders verifies that leaving MaxConcurrentRenders unset falls
+// back to the GOMAXPROCS-derived default and sizes the semaphore accordingly.
+func TestWorkerInitDefaultsMaxConcurrentRenders(t *testing.T) {
+	t.Parallel()
+
+	w := Worker{
+		HTTPClient:          http.DefaultClient,
+		URLSigningSecret:    "secret",
+		TraceExtractor:      traceExtractor,
+		StorageBucketRegion: map[string]string{"bucket-1": "eu-central-1"},
+		getS3Client:         func(string) (workerS3API, error) { return fakeS3{}, nil },
+	}
+	require.NoError(t, w.Init())
+
+	require.Equal(t, runtime.GOMAXPROCS(0)*defaultRendersPerCPU, w.MaxConcurrentRenders)
+	require.Equal(t, w.MaxConcurrentRenders, cap(w.renderSem))
+}
+
+// TestWorkerAcquireRenderSlot verifies the semaphore bounds concurrency: once the limit is reached a
+// further acquire blocks until a slot is released, and honours context cancellation while waiting.
+func TestWorkerAcquireRenderSlot(t *testing.T) {
+	t.Parallel()
+
+	w := Worker{
+		HTTPClient:           http.DefaultClient,
+		URLSigningSecret:     "secret",
+		TraceExtractor:       traceExtractor,
+		StorageBucketRegion:  map[string]string{"bucket-1": "eu-central-1"},
+		getS3Client:          func(string) (workerS3API, error) { return fakeS3{}, nil },
+		MaxConcurrentRenders: 1,
+	}
+	require.NoError(t, w.Init())
+
+	// Take the only slot.
+	release, err := w.acquireRenderSlot(context.Background())
+	require.NoError(t, err)
+
+	// A second acquire must fail once its context is done rather than wait forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err = w.acquireRenderSlot(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Releasing the first slot lets the next acquire succeed.
+	release()
+	release2, err := w.acquireRenderSlot(context.Background())
+	require.NoError(t, err)
+	release2()
+}
+
 // fakeS3 returns a fresh reader over payload on every call so concurrent fetches don't share a drained buffer.
 type fakeS3 struct {
 	payload []byte


### PR DESCRIPTION
## Problem

Prod pods (`sign-platform/lazyraster-v2`, eu-central-1) are being **OOMKilled** and restarted repeatedly, which surfaces to callers as intermittent **503s** while a killed pod restarts and fails its readiness probe.

Evidence from the cluster:
```
Last State:    Terminated
  Reason:      OOMKilled
  Exit Code:   137
Restart Count: 9            # single pod, over ~20h
Limits: memory 2Gi
```
Yet steady-state memory is low — `kubectl top` shows **~130–230Mi** per pod against the 2Gi limit (HPA reports `memory: 22%/90%`). So this is **not a gradual leak**; rasterization is **spiky**.

## Root cause

Each `Worker.Process` / `Worker.Render` holds the whole source PDF and the rendered image in memory and drives allocations in the **lazypdf C layer** that `GOMEMLIMIT` cannot account for. There was **no cap on concurrent renders**, so a burst of large/complex documents stacks enough simultaneous allocations to blow past the 2Gi container limit, and the kernel OOM-kills the container.

## Change

- Add a bounded-concurrency **semaphore** on `Worker` limiting how many rasterizations run at once.
- The slot is acquired **before the file is pulled into memory**, so payloads can't accumulate without a slot.
- Configurable via **`MAX_CONCURRENT_RENDERS`**; defaults to `GOMAXPROCS * 2` (= 4 with the current 2-CPU limit).
- Acquisition **respects the request context**: under overload, excess requests fail with the context error (a graceful timeout via the handler's existing `ctx.Err()` check) instead of triggering an OOM that takes down every in-flight request on the pod.

## Scope / follow-up

This is the **application-side mitigation**. The container memory `limits`/`requests` live in the **deploy repo** (not here) and should be revisited alongside this — likely a modest bump plus alerting on `container_memory_working_set_bytes` and OOMKill events. `Worker.Metadata` (which also reads the whole file) is intentionally left unbounded for now as it is not part of the rasterization path implicated in the OOMs.

## Testing

- `go build ./...`, `go vet ./...` — clean.
- `go test -race ./internal/...` — pass.
- New unit tests: `TestWorkerInitDefaultsMaxConcurrentRenders` (default sizing) and `TestWorkerAcquireRenderSlot` (bound enforced + context cancellation honoured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)