### PR TITLE
Handle SIGTERM so the graceful shutdown actually runs (page-image 503s)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,12 +8,20 @@ import (
 	"os/signal"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/rs/zerolog"
 
 	"github.com/nitro/lazyraster/v2/internal"
 )
+
+// shutdownTimeout bounds the graceful shutdown that a termination signal triggers. It has to exceed
+// the router's own 15s request timeout (internal/transport.Server.initMiddleware) so an in-flight
+// render finishes on its own terms instead of tripping this deadline and turning a clean stop into a
+// Fatal, and it has to stay comfortably inside the pod's terminationGracePeriodSeconds so kubelet
+// does not SIGKILL us part-way through.
+const shutdownTimeout = 20 * time.Second
 
 func main() {
 	var (
@@ -51,7 +59,7 @@ func main() {
 	client.Start()
 
 	exitStatus := waitHandler()
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	if err := client.Stop(ctx); err != nil {
 		ctxCancel()
 		logger.Fatal().Err(err).Msg("Fail to stop the client")
@@ -62,16 +70,28 @@ func main() {
 
 func wait(logger zerolog.Logger) (func(error), func() int) {
 	signalChan := make(chan os.Signal, 2)
+
+	// SIGTERM is what Kubernetes and `docker stop` send to ask for a shutdown; SIGINT covers a local
+	// Ctrl-C. Both must be registered: a signal absent from this list keeps its default disposition,
+	// and for SIGTERM that means the runtime kills the process outright, so the handler below never
+	// returns and main never reaches client.Stop. In-flight connections are then severed rather than
+	// drained, which callers' Envoy sidecars report as UC and turn into 503s.
+	//
+	// Registering here rather than inside the handler also covers the window between process start
+	// and the caller invoking the handler, during which the client is already accepting requests.
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+
 	var exitStatus int32
 	asyncError := func(err error) {
 		logger.Error().Err(err).Msg("Async error happened")
-		signalChan <- os.Interrupt
+		// Record the failure before waking the handler: it reads exitStatus as soon as it receives,
+		// so incrementing afterwards races and can report a clean exit for a crash.
 		atomic.AddInt32(&exitStatus, 1)
+		signalChan <- os.Interrupt
 	}
 	handler := func() int {
-		signal.Notify(signalChan, os.Interrupt)
 		<-signalChan
-		return (int)(exitStatus)
+		return int(atomic.LoadInt32(&exitStatus))
 	}
 	return asyncError, handler
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitHandlerReturnsOnTerminationSignal pins the behaviour that makes the graceful shutdown in
+// main reachable at all. A signal missing from signal.Notify keeps its default disposition, and for
+// SIGTERM that means the runtime terminates the process immediately: the handler never returns,
+// client.Stop is never called, and in-flight connections are severed instead of drained.
+//
+// Note the failure mode if the SIGTERM registration is ever dropped: this test does not report a
+// normal assertion failure, it takes the whole test binary down with it and `go test` reports
+// "signal: terminated". That is still a hard failure, and it is the same thing production does.
+//
+// These cases must not run in parallel — signal registration is process-wide state.
+func TestWaitHandlerReturnsOnTerminationSignal(t *testing.T) {
+	for name, sig := range map[string]syscall.Signal{
+		"SIGTERM": syscall.SIGTERM,
+		"SIGINT":  syscall.SIGINT,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, waitHandler := wait(zerolog.Nop())
+			t.Cleanup(func() { signal.Reset(os.Interrupt, syscall.SIGTERM) })
+
+			done := make(chan int, 1)
+			go func() { done <- waitHandler() }()
+
+			// wait registered the handler before returning, so the signal lands in its buffered
+			// channel rather than killing the binary; no need to wait for the goroutine first.
+			require.NoError(t, syscall.Kill(syscall.Getpid(), sig))
+
+			select {
+			case exitStatus := <-done:
+				require.Zero(t, exitStatus, "a termination signal is a clean exit, not a failure")
+			case <-time.After(5 * time.Second):
+				t.Fatal("waitHandler did not return; the graceful shutdown in main would be skipped")
+			}
+		})
+	}
+}
+
+// TestWaitHandlerAsyncErrorExitsNonZero pins that an async failure still unblocks the handler and
+// still reports a non-zero exit status, so moving signal.Notify out of the handler cannot quietly
+// change how a startup or runtime failure is surfaced.
+func TestWaitHandlerAsyncErrorExitsNonZero(t *testing.T) {
+	asyncError, waitHandler := wait(zerolog.Nop())
+	t.Cleanup(func() { signal.Reset(os.Interrupt, syscall.SIGTERM) })
+
+	done := make(chan int, 1)
+	go func() { done <- waitHandler() }()
+
+	asyncError(errors.New("something failed asynchronously"))
+
+	select {
+	case exitStatus := <-done:
+		require.Equal(t, 1, exitStatus, "an async error must not be reported as a clean exit")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitHandler did not return after an async error")
+	}
+}
+
+// TestShutdownTimeoutExceedsRequestTimeout guards the relationship the shutdownTimeout comment
+// relies on: it must be longer than the router's request timeout, otherwise a slow but healthy
+// render trips the shutdown deadline and main turns a clean stop into a Fatal.
+func TestShutdownTimeoutExceedsRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	// internal/transport.Server.initMiddleware: s.router.Use(m.timeout(15 * time.Second))
+	const routerRequestTimeout = 15 * time.Second
+
+	require.Greater(t, shutdownTimeout, routerRequestTimeout)
+}


### PR DESCRIPTION
## Problem

`wait` registers only `os.Interrupt` (SIGINT) — but Kubernetes sends **SIGTERM**:

```go
// cmd/main.go, before
handler := func() int {
    signal.Notify(signalChan, os.Interrupt)   // SIGINT only
    <-signalChan                              // ← blocks forever on SIGTERM
    return (int)(exitStatus)
}
```

A signal absent from `signal.Notify` keeps its **default disposition**: the Go runtime resets the handler to `SIG_DFL` and re-raises, killing the process at status 143 with no unwinding. So everything after that channel receive is unreachable in production:

```go
exitStatus := waitHandler()                                  // never returns
ctx, ctxCancel := context.WithTimeout(ctx, 10*time.Second)   // never runs
client.Stop(ctx)                                             // never runs
```

`client.Stop` → `Server.Stop` → `http.Server.Shutdown` is correct code that is simply **never reached**. This is not missing functionality, it is unreachable functionality.

PID 1 in the container is the binary itself (`/opt/nitro/lazyraster/lazyraster`) — no `tini`/`dumb-init`, no shell wrapper — so SIGTERM lands directly on the Go process and is ignored.

## Impact

The process dies mid-flight, the kernel tears down every socket without a graceful close, and sockets with an unwritten response get **RST**. The caller's Envoy sidecar classifies that as `UC` (upstream connection termination) and synthesises a **503**.

In EU prod this fires on **every pod termination**, and terminations are frequent — the `lazyraster-v2` HPA oscillates between `min: 2` and `max: 5`, producing **9 scaling events in a 39-minute window**. Every user-facing render 503 that day landed on a scale-down **to the second**:

| 503 in SWS logs | lazyraster event, same second |
|---|---|
| 13:09:49 | `Scaled down … 5 to 3` + `Killing` ×2 |
| 13:28:51 (×2 traces) | `Scaled down … 5 to 4` + `Killing` |
| 13:32:52 | `Scaled down … 3 to 2` + `Killing` |

Example trace [`6a74879d0000000073edea892136d8ec`](https://app.datadoghq.eu/apm/trace/6a74879d0000000073edea892136d8ec) — both the initial attempt and the retry carry `response_flags: UC`, and there is **no `lazyraster-v2` server span at all**: the request never reached a handler. Terminated pods ended `pod_phase: failed` rather than `Succeeded`, corroborating a signal-killed process.

Unsampled volume: **≈299 errors / 7 days (~43/day)** across the two page-image endpoints (`trace.pekko_http.request.errors`). Low in aggregate but clustered — a document viewer loads many page tiles concurrently, so one scale-in breaks several at once for whoever is mid-document.

## Change

- **Register `syscall.SIGTERM`** alongside `os.Interrupt`. This is the fix.
- **Register in `wait` rather than inside the returned handler.** `wait` is called before `client.Init`/`client.Start`, so this also closes the window where the client is already serving but the handler has not yet been invoked.
- **Raise the shutdown budget 10s → 20s** as a named `shutdownTimeout`. The router applies its own 15s request timeout (`Server.initMiddleware`), so a slow but healthy render could outlast a 10s `Shutdown`, return `DeadlineExceeded`, and turn a clean stop into a `Fatal`. 20s stays well inside the pod's 30s `terminationGracePeriodSeconds`.
- **Fix a pre-existing race in `asyncError`** — it incremented `exitStatus` *after* waking the handler, which reads it immediately, so an async crash could report a clean exit. Increment first, load atomically. Unrelated to SIGTERM and easy to drop if you'd rather keep this single-purpose; it is two lines in the function already being edited.

## Scope — this alone does not close the incident

This fixes **in-flight** requests. It does not fix the endpoint-convergence race: pod deletion starts two unsynchronised sequences — kubelet sending SIGTERM, and EndpointSlice → istiod → xDS propagating the removal to callers' Envoys. Nothing orders them, so requests arriving after the listener closes but before Envoy converges still hit a closed listener.

That needs a `preStop` delay in **`lazyraster-deploy`** (`lifecycle` is currently `null`), which is in progress separately. Expect `@response_flags:UC` to drop substantially but not to zero until both land.

Two other contributors, both outside this repo: the HPA has `behavior: null` and a 4× `requests.cpu`-to-`limits.cpu` gap (500m vs 2000m) that makes its signal effectively binary and drives the thrash; and `signing-workflow-service` retries the render **11ms** later with no backoff, so the retry re-resolves against the same stale endpoint set — which is why every burst is exactly two 503s.

Not related to lazyraster #408 (OOMKill is a different path to the same `UC`; `memory.max` has since been raised to 4Gi and pods show `restarts=0`), nor to SWS #1300 (the example trace ran *on* that build).

## Testing

New `cmd/main_test.go`:

- `TestWaitHandlerReturnsOnTerminationSignal` — SIGTERM and SIGINT both unblock the handler and report exit status 0. Not parallel: signal registration is process-wide.
- `TestWaitHandlerAsyncErrorExitsNonZero` — an async failure still unblocks and still reports non-zero, so moving `signal.Notify` cannot quietly change how failures surface.
- `TestShutdownTimeoutExceedsRequestTimeout` — guards the invariant the `shutdownTimeout` comment relies on.

**Verified against the bug, not just against the fix.** With the SIGTERM registration removed:

```
# github.com/nitro/lazyraster/v2/cmd.test
signal: terminated
FAIL    github.com/nitro/lazyraster/v2/cmd    0.954s
```

Note that failure mode is unusual and is documented in the test: it does not report a normal assertion failure, it takes the test binary down and `go test` reports `signal: terminated`. That is a hard failure, and it is the same thing production does.

`go test -race ./...` green across all packages · `gofmt` and `go vet` clean · longest new line 101 chars against the `lll` limit of 120.

## How to verify in prod

Don't watch the endpoint error rate — at ~43/day it is too low-volume to show a change quickly. Watch the Envoy flag. Under load, delete one lazyraster pod and query APM spans:

```
service:signing-workflow-service.nitro-cloud resource_name:lazyraster-v2:80/* @response_flags:UC
```

Today this returns hits at every scale-in second. With this fix plus the `preStop` hook it should return zero.

## Jira Ticket

_TBD — needs a ticket number._

🤖 Generated with [Claude Code](https://claude.com/claude-code)